### PR TITLE
Feature/validate launch deps

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,16 +3,22 @@
 Validates and formats `package.xml` files to enforce consistency and ROS 2 schema compliance.
 
 ### ✅ What it does:
-- Validates against [package_format3.xsd](http://download.ros.org/schema/package_format3.xsd)
-- Corrects erros such as
-  - wrong order of xml elements
-- Ensures dependencies are:
+- XML Schema Validation & Correction
+  - Validates against [package_format3.xsd](http://download.ros.org/schema/package_format3.xsd)
+  - Fixes ordering errors, formatting errors, ...
+- Dependency Grouping & Sorting
   - Grouped by type (e.g. `build_depend`, `test_depend`)
   - Sorted alphabetically within each group
-- Leaves comments and indentation **unchanged**
-- verifies that all rodsdep keys exist (optional)
-- compares build dependencies and test dependencies with dependencies in the CMakeLists.txt (optional)
-- automatically inserts missing package xml dependencies from the CMakeList as `<depend>` or `<build_depend>` (optional)
+- Non-Destructive Edits
+  - Leaves comments and indentation **unchanged**
+- Launch-File Dependency Validation
+  - Scans Python (.py), YAML (.yaml/.yml), and XML (.xml) launch files for package references
+  - validates and corrects that all referenced pkgs are declared in the package xml (as `<exec_depend>` or `<depend>`)
+- Rosdep Key Checking
+  - verifies that all declared pkgs exist as rodsdep key (optional)
+- CMakeFile Comparison and Synchronization
+  - compares build dependencies and test dependencies with dependencies in the CMakeLists.txt (optional)
+  - automatically inserts missing package xml dependencies from the CMakeList as `<depend>` or `<build_depend>` (optional)
 
 
 #### Example: Enforced Grouping of the dependencies
@@ -57,14 +63,15 @@ Example with verbose logging:
 ```
 package-xml-validator ~/hector/src/hector_gamepad_manager/hector_gamepad_plugin_interface --check-only --compare-with-cmake --verbose
 Processing hector_gamepad_plugin_interface...
-✅ [1/8] Check for invalid tags passed.
-✅ [2/8] Check for empty lines passed.
-✅ [3/8] Check for duplicate elements passed.
-✅ [4/8] Check element occurrences passed.
-✅ [5/8] Check element order passed.
-✅ [6/8] Check dependency order passed.
-✅ [7/8] Check ROS dependencies passed.
-✅ [8/8] Check CMake dependencies passed.
+✅ [1/9] Check for invalid tags passed.
+✅ [2/9] Check for empty lines passed.
+✅ [3/9] Check for duplicate elements passed.
+✅ [4/9] Check element occurrences passed.
+✅ [5/9] Check element order passed.
+✅ [6/9] Check dependency order passed.
+✅ [7/9] Check launch dependencies passed.
+✅ [8/9] Check ROS dependencies passed.
+✅ [9/9] Check CMake dependencies passed.
 🎉 All `package.xml` files are valid and nicely formatted. 🚀
 ```
 

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -13,14 +13,20 @@ import argparse
 
 REGEX_EXPR = [
     # YAML-style:  pkg: <pkg_name>
-    r"(?:package|pkg)\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
-    # Python/XML attribute:  package = <pkg_name>  or  pkg = <pkg_name>
-    r"(?:package|pkg)\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    r"pkg\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    # Hector launch component:  package: <pkg_name>
+    r"package\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    # Python Node call: Node(..., package='<pkg_name>', ...)
+    r"Node\s*\(\s*[^)]*?package\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    # XML node tag: <node pkg="foo" ...>
+    r"<node[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
     # get_package_share_directory('foo')
     r"get_package_share_directory\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
     # FindPackageShare('foo')
     r"FindPackageShare\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
-    # $(find-pkg-share foo) e.g. in xml or yaml launch files
+    # FindPackageShare(package='foo')
+    r"FindPackageShare\(\s*package\s*=\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    # $(find-pkg-share foo)
     r"\$\(\s*find-pkg-share\s+([A-Za-z0-9_]+)\s*\)",
 ]
 
@@ -28,7 +34,7 @@ REGEX_EXPR = [
 COMPILED = [re.compile(rx) for rx in REGEX_EXPR]
 
 
-def scan_file(path, found: set[str]):
+def scan_file(path, found: set[str], verbose: bool = False):
     """Apply every regex to the file and add matches to `found`."""
     try:
         with open(path, encoding="utf-8") as f:
@@ -36,12 +42,16 @@ def scan_file(path, found: set[str]):
     except (UnicodeDecodeError, OSError):
         return
 
-    for rx in COMPILED:
+    for i, rx in enumerate(COMPILED):
         for m in rx.finditer(text):
             found.add(m.group(1))
+            if verbose:
+                print(
+                    f"Found package '{m.group(1)}' in {os.path.basename(path)} with regex {REGEX_EXPR[i]}"
+                )
 
 
-def scan_files(launch_dir: str) -> list[str]:
+def scan_files(launch_dir: str, verbose: bool = False) -> list[str]:
     if not os.path.isdir(launch_dir):
         print(f"Error: '{launch_dir}' is not a directory.")
         return []
@@ -51,7 +61,7 @@ def scan_files(launch_dir: str) -> list[str]:
     for root, _, files in os.walk(launch_dir):
         for fn in files:
             if fn.endswith((".py", ".xml", ".yaml", ".launch", ".yml")):
-                scan_file(os.path.join(root, fn), pkgs)
+                scan_file(os.path.join(root, fn), pkgs, verbose)
     return list(pkgs)
 
 
@@ -60,12 +70,23 @@ def parse_args():
         description="Extract referenced ROS 2 package names from launch files via regex."
     )
     p.add_argument("launch_dir", help="Path to your package's launch/ directory")
+    p.add_argument(
+        "-v", "--verbose", action="store_true", help="Print found packages to stdout"
+    )
+    # parse args
     args = p.parse_args()
     pkgs = scan_files(args.launch_dir)
-    print("Found packages:")
-    for pkg in sorted(pkgs):
-        print(f"  - {pkg}")
+    if args.verbose:
+        print("Found packages:")
+        for pkg in sorted(pkgs):
+            print(f"  - {pkg}")
 
 
 if __name__ == "__main__":
-    parse_args()
+    # parse_args()
+    file = "/home/aljoscha-schmidt/hector/src/simulation_scenario_robocup_gazebo/launch/launch_world.launch.py"
+    found = set()
+    scan_file(file, found, verbose=True)
+    print("Found packages:")
+    for pkg in sorted(found):
+        print(f"  - {pkg}")

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+find_launch_dependencies.py
+
+Recursively search a ROS 2 package's launch/ folder and extract
+all referenced ROS 2 package names via a small set of regexes.
+"""
+
+import os
+import re
+import argparse
+
+
+REGEX_EXPR = [
+    # YAML-style:  pkg: <pkg_name>
+    r"pkg\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    # Python/XML attribute:  package = <pkg_name>  or  pkg = <pkg_name>
+    r"(?:package|pkg)\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    # get_package_share_directory('foo')
+    r"get_package_share_directory\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    # FindPackageShare('foo')
+    r"FindPackageShare\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    # $(find-pkg-share foo) e.g. in xml or yaml launch files
+    r"\$\(\s*find-pkg-share\s+([A-Za-z0-9_]+)\s*\)",
+]
+
+# Compile once for speed
+COMPILED = [re.compile(rx) for rx in REGEX_EXPR]
+
+def scan_file(path, found):
+    """Apply every regex to the file and add matches to `found`."""
+    try:
+        text = open(path, encoding='utf-8').read()
+    except (UnicodeDecodeError, OSError):
+        return
+    for rx in COMPILED:
+        for m in rx.finditer(text):
+            found.add(m.group(1))
+
+def scan_files(launch_dir: str) -> list[str]:
+    if not os.path.isdir(launch_dir):
+        print(f"Error: '{launch_dir}' is not a directory.")
+        return []
+
+    pkgs = set()
+
+    for root, _, files in os.walk(launch_dir):
+        for fn in files:
+            scan_file(os.path.join(root, fn), pkgs)
+    return list(pkgs)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Extract referenced ROS 2 package names from launch files via regex."
+    )
+    p.add_argument("launch_dir",
+                   help="Path to your package's launch/ directory")
+    args = p.parse_args()
+    pkgs = scan_files(args.launch_dir)
+    print("Found packages:")
+    for pkg in sorted(pkgs):
+        print(f"  - {pkg}")
+
+if __name__ == "__main__":
+    parse_args()

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -27,15 +27,17 @@ REGEX_EXPR = [
 # Compile once for speed
 COMPILED = [re.compile(rx) for rx in REGEX_EXPR]
 
+
 def scan_file(path, found):
     """Apply every regex to the file and add matches to `found`."""
     try:
-        text = open(path, encoding='utf-8').read()
+        text = open(path, encoding="utf-8").read()
     except (UnicodeDecodeError, OSError):
         return
     for rx in COMPILED:
         for m in rx.finditer(text):
             found.add(m.group(1))
+
 
 def scan_files(launch_dir: str) -> list[str]:
     if not os.path.isdir(launch_dir):
@@ -54,13 +56,13 @@ def parse_args():
     p = argparse.ArgumentParser(
         description="Extract referenced ROS 2 package names from launch files via regex."
     )
-    p.add_argument("launch_dir",
-                   help="Path to your package's launch/ directory")
+    p.add_argument("launch_dir", help="Path to your package's launch/ directory")
     args = p.parse_args()
     pkgs = scan_files(args.launch_dir)
     print("Found packages:")
     for pkg in sorted(pkgs):
         print(f"  - {pkg}")
+
 
 if __name__ == "__main__":
     parse_args()

--- a/package_xml_validation/helpers/pkg_xml_formatter.py
+++ b/package_xml_validation/helpers/pkg_xml_formatter.py
@@ -370,6 +370,22 @@ class PackageXmlFormatter:
             if isinstance(elem.tag, str) and elem.tag in test_deps and elem.text:
                 test_dependencies.append(elem.text.strip())
         return test_dependencies
+    
+    def retrieve_exec_dependencies(self, root):
+        """Retrieve all exec dependencies from the XML file."""
+        exec_dependencies = []
+        exec_deps = ["exec_depend", "depend"]
+        for elem in root:
+            if isinstance(elem.tag, str) and elem.tag in exec_deps and elem.text:
+                exec_dependencies.append(elem.text.strip())
+        return exec_dependencies
+
+    def get_package_name(self, root) -> str | None:
+        """Retrieve the package name from the XML file."""
+        name_elem = root.find("name")
+        if name_elem is not None and name_elem.text:
+            return name_elem.text.strip()
+        return None
 
     def add_dependencies(self, root, dependencies, dep_type):
         """Add dependencies to the XML file."""

--- a/package_xml_validation/helpers/pkg_xml_formatter.py
+++ b/package_xml_validation/helpers/pkg_xml_formatter.py
@@ -370,7 +370,7 @@ class PackageXmlFormatter:
             if isinstance(elem.tag, str) and elem.tag in test_deps and elem.text:
                 test_dependencies.append(elem.text.strip())
         return test_dependencies
-    
+
     def retrieve_exec_dependencies(self, root):
         """Retrieve all exec dependencies from the XML file."""
         exec_dependencies = []
@@ -417,15 +417,12 @@ class PackageXmlFormatter:
                 insert_position = 0
                 first_of_group = None
                 for i, elm in enumerate(root):
-                    if (
-                        isinstance(elm.tag, str)
-                        and elm.tag == dep_type
-                    ):
+                    if isinstance(elm.tag, str) and elm.tag == dep_type:
                         if first_of_group is None:
                             first_of_group = i
                             insert_position = i
                         if elm.text < new_elem.text:
-                            insert_position = i+1
+                            insert_position = i + 1
             root.insert(insert_position, new_elem)
             # adapt empty lines -> in case element prior ends with empty line move it to the new element
             if insert_position > 0 and insert_position > first_of_group:
@@ -438,7 +435,6 @@ class PackageXmlFormatter:
                 next_element = root[insert_position + 1]
                 if next_element.tag != new_elem.tag:
                     new_elem.tail = "\n\n" + indendantion
-                
 
     def check_and_format_files(self, package_xml_files) -> Tuple[bool, bool]:
         """Check and format package.xml files if self.check_only is False.
@@ -479,7 +475,9 @@ class PackageXmlFormatter:
                 all_valid = False
                 self.logger.debug(f"❌ [3/6] Duplicate elements found in {xml_file}.")
             else:
-                self.logger.debug(f"✅ [3/6] No duplicate elements found in {xml_file}.")
+                self.logger.debug(
+                    f"✅ [3/6] No duplicate elements found in {xml_file}."
+                )
 
             if not self.check_element_occurrences(root, xml_file):
                 all_valid = False
@@ -503,7 +501,9 @@ class PackageXmlFormatter:
                     f"❌ [6/6] Dependency order in {xml_file} is incorrect."
                 )
             else:
-                self.logger.debug(f"✅ [6/6] Dependency order in {xml_file} is correct.")
+                self.logger.debug(
+                    f"✅ [6/6] Dependency order in {xml_file} is correct."
+                )
 
             if not all_valid and not self.check_only:
                 # Write back to file

--- a/package_xml_validation/helpers/workspace.py
+++ b/package_xml_validation/helpers/workspace.py
@@ -55,7 +55,7 @@ def find_package_dir(path: Path) -> Path:
 
     raise ValueError(
         f"No *package.xml* found relative to '{path}'. Is it really part of a "
-        "ROS 2 workspace?"
+        "ROS 2 workspace?"
     )
 
 
@@ -78,7 +78,7 @@ def find_workspace_root(start: Path) -> Path:
         here = here.parent
 
     raise ValueError(
-        f"Could not locate a ROS 2 workspace root above {start}. "
+        f"Could not locate a ROS 2 workspace root above {start}. "
         "Does the path actually reside in a <ws>/src/<pkg> hierarchy?"
     )
 

--- a/package_xml_validation/package_xml_validator.py
+++ b/package_xml_validation/package_xml_validator.py
@@ -154,27 +154,25 @@ class PackageXmlValidator:
                 text=True,
             )
             if result.returncode != 0:
-                self.logger.error(
-                    f"XML validation error in {xml_file}:"
-                )
+                self.logger.error(f"XML validation error in {xml_file}:")
                 self.logger.error(result.stderr)
                 return False
             return True
         except Exception as e:
             self.logger.error(f"Error running xmllint on {xml_file}: {e}")
             return False
-        
-    def validate_launch_dependencies(self, root, package_xml_file: str, package_name:str, exec_deps: List[str]):
+
+    def validate_launch_dependencies(
+        self, root, package_xml_file: str, package_name: str, exec_deps: List[str]
+    ):
         """Validate launch dependencies in the package.xml file."""
-        launch_dir = os.path.join(
-            os.path.dirname(package_xml_file), "launch"
-        )
+        launch_dir = os.path.join(os.path.dirname(package_xml_file), "launch")
         if not os.path.exists(launch_dir):
             self.logger.debug(
                 f"No launch directory found for {package_xml_file}. Skipping launch dependency validation."
             )
             return True
-        
+
         launch_deps = scan_files(launch_dir)
         missing_deps = [
             dep for dep in launch_deps if dep not in exec_deps and dep != package_name
@@ -183,16 +181,14 @@ class PackageXmlValidator:
             self.logger.warning(
                 f"Missing launch dependencies in {package_name}/package.xml: \n\t - {'\n\t - '.join(missing_deps)}"
             )
-        
+
             if self.check_only:
                 return False
             else:
                 self.logger.info(
                     f"Auto-filling {len(missing_deps)} missing launch dependencies in {package_name}/package.xml."
                 )
-                self.formatter.add_dependencies(
-                    root, missing_deps, "exec_depend"
-                )
+                self.formatter.add_dependencies(root, missing_deps, "exec_depend")
                 return False
         return True
 
@@ -282,7 +278,7 @@ class PackageXmlValidator:
                 root,
                 xml_file,
             )
-            
+
             self.perform_check(
                 "Check launch dependencies",
                 self.validate_launch_dependencies,
@@ -399,30 +395,26 @@ def main():
     )
 
     args = parser.parse_args()
-    
+
     # if file not given and src is empty, assume current directory
     if not args.file and not args.src:
         args.src = [os.getcwd()]
-        
+
     # if env var ROS_DISTRO not avilable, force skip rosdep key validation
     if not args.skip_rosdep_key_validation and "ROS_DISTRO" not in os.environ:
         args.skip_rosdep_key_validation = True
         print(
             "ROS_DISTRO environment variable not set. Skipping rosdep key validation."
         )
-    
+
     # if --skip-rosdep-key-validation is set -> compare with cmake and auto-fill missing deps are not possible
     if args.skip_rosdep_key_validation and args.compare_with_cmake:
-        print(
-            "Cannot use --compare-with-cmake with --skip-rosdep-key-validation."
-        )
+        print("Cannot use --compare-with-cmake with --skip-rosdep-key-validation.")
         args.compare_with_cmake = False
-    
+
     # --auto-fill-missing-deps is only possible with --compare-with-cmake
     if not args.compare_with_cmake and args.auto_fill_missing_deps:
-        print(
-            "Cannot use --auto-fill-missing-deps without --compare-with-cmake."
-        )
+        print("Cannot use --auto-fill-missing-deps without --compare-with-cmake.")
         args.auto_fill_missing_deps = False
 
     formatter = PackageXmlValidator(

--- a/package_xml_validation/package_xml_validator.py
+++ b/package_xml_validation/package_xml_validator.py
@@ -166,14 +166,24 @@ class PackageXmlValidator:
         self, root, package_xml_file: str, package_name: str, exec_deps: List[str]
     ):
         """Validate launch dependencies in the package.xml file."""
-        launch_dir = os.path.join(os.path.dirname(package_xml_file), "launch")
-        if not os.path.exists(launch_dir):
+
+        def extract_launch_deps(folder_names: List[str]) -> List[str]:
+            """Extract launch dependencies from the folder names."""
+            launch_deps = []
+            for folder in folder_names:
+                launch_dir = os.path.join(os.path.dirname(package_xml_file), folder)
+                if os.path.isdir(launch_dir):
+                    launch_deps.extend(scan_files(launch_dir))
+            return launch_deps
+
+        launch_folder_names = ["launch", "components"]
+        launch_deps = extract_launch_deps(launch_folder_names)
+        if not launch_deps:
             self.logger.debug(
-                f"No launch directory found for {package_xml_file}. Skipping launch dependency validation."
+                f"No launch dependencies found in {package_name}/package.xml."
             )
             return True
 
-        launch_deps = scan_files(launch_dir)
         missing_deps = [
             dep for dep in launch_deps if dep not in exec_deps and dep != package_name
         ]

--- a/tests/examples/launch_examples/hector_launch_component.yaml
+++ b/tests/examples/launch_examples/hector_launch_component.yaml
@@ -1,0 +1,5 @@
+description: Announcer for Athena Multi Robot
+provides: announcement
+launch:
+  package: athena_announcer
+  executable: athena_announcer

--- a/tests/examples/launch_examples/python_example.launch.py
+++ b/tests/examples/launch_examples/python_example.launch.py
@@ -1,0 +1,91 @@
+# from https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, GroupAction, IncludeLaunchDescription
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node, PushROSNamespace
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    launch_dir = PathJoinSubstitution(
+        [FindPackageShare("demo_nodes_cpp"), "launch", "topics"]
+    )
+    return LaunchDescription(
+        [
+            # args that can be set from the command line or a default will be used
+            DeclareLaunchArgument("background_r", default_value="0"),
+            DeclareLaunchArgument("background_g", default_value="255"),
+            DeclareLaunchArgument("background_b", default_value="0"),
+            DeclareLaunchArgument("chatter_py_ns", default_value="chatter/py/ns"),
+            DeclareLaunchArgument("chatter_xml_ns", default_value="chatter/xml/ns"),
+            DeclareLaunchArgument("chatter_yaml_ns", default_value="chatter/yaml/ns"),
+            # include another launch file
+            IncludeLaunchDescription(
+                PathJoinSubstitution([launch_dir, "talker_listener_launch.py"])
+            ),
+            # include a Python launch file in the chatter_py_ns namespace
+            GroupAction(
+                actions=[
+                    # push_ros_namespace first to set namespace of included nodes for following actions
+                    PushROSNamespace("chatter_py_ns"),
+                    IncludeLaunchDescription(
+                        PathJoinSubstitution([launch_dir, "talker_listener_launch.py"])
+                    ),
+                ]
+            ),
+            # include a xml launch file in the chatter_xml_ns namespace
+            GroupAction(
+                actions=[
+                    # push_ros_namespace first to set namespace of included nodes for following actions
+                    PushROSNamespace("chatter_xml_ns"),
+                    IncludeLaunchDescription(
+                        PathJoinSubstitution([launch_dir, "talker_listener_launch.xml"])
+                    ),
+                ]
+            ),
+            # include a yaml launch file in the chatter_yaml_ns namespace
+            GroupAction(
+                actions=[
+                    # push_ros_namespace first to set namespace of included nodes for following actions
+                    PushROSNamespace("chatter_yaml_ns"),
+                    IncludeLaunchDescription(
+                        PathJoinSubstitution(
+                            [launch_dir, "talker_listener_launch.yaml"]
+                        )
+                    ),
+                ]
+            ),
+            # start a turtlesim_node in the turtlesim1 namespace
+            Node(
+                package="turtlesim",
+                namespace="turtlesim1",
+                executable="turtlesim_node",
+                name="sim",
+            ),
+            # start another turtlesim_node in the turtlesim2 namespace
+            # and use args to set parameters
+            Node(
+                package="turtlesim",
+                namespace="turtlesim2",
+                executable="turtlesim_node",
+                name="sim",
+                parameters=[
+                    {
+                        "background_r": LaunchConfiguration("background_r"),
+                        "background_g": LaunchConfiguration("background_g"),
+                        "background_b": LaunchConfiguration("background_b"),
+                    }
+                ],
+            ),
+            # perform remap so both turtles listen to the same command topic
+            Node(
+                package="turtlesim",
+                executable="mimic",
+                name="mimic",
+                remappings=[
+                    ("/input/pose", "/turtlesim1/turtle1/pose"),
+                    ("/output/cmd_vel", "/turtlesim2/turtle1/cmd_vel"),
+                ],
+            ),
+        ]
+    )

--- a/tests/examples/launch_examples/python_gazebo_launch.py
+++ b/tests/examples/launch_examples/python_gazebo_launch.py
@@ -1,0 +1,120 @@
+from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution, TextSubstitution
+from launch_ros.substitutions import FindPackageShare, FindPackage
+from launch.actions import AppendEnvironmentVariable, SetEnvironmentVariable
+from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import Node, SetParameter
+import os
+
+
+def generate_launch_description():
+
+    # Use simulation time
+    set_use_sim_time = SetParameter(name="use_sim_time", value=True)
+
+    # Set the path to the Gazebo ROS package
+    ros_gz_sim = FindPackageShare("ros_gz_sim")
+
+    # Set the path to map package.
+    this_pkg = FindPackageShare(package="simulation_scenario_robocup_gazebo")
+    # Set the path to the SDF model files.
+    set_env_vars_resources = AppendEnvironmentVariable(
+        "GZ_SIM_RESOURCE_PATH",
+        os.path.join(
+            get_package_share_directory("simulation_scenario_robocup_gazebo"),
+            "nist_arena_models",
+        ),
+    )
+
+    # Set the default path to the world file
+    map_id = LaunchConfiguration("map_id", default="exp1")
+    map_path = PathJoinSubstitution(
+        [
+            this_pkg,
+            "worlds",
+            LaunchConfiguration("map_file", default=[map_id, ".world"]),
+        ]
+    )
+
+    # Load parameter bridge config
+    global_bridge_params = os.path.join(
+        get_package_share_directory("simulation_scenario_robocup_gazebo"),
+        "config",
+        "global_gazebo_bridge_params.yaml",
+    )
+
+    # Specify the actions
+    declare_map_cmd = DeclareLaunchArgument(
+        name="map_id", default_value="exp1", description="Map to load"
+    )
+
+    # conditional gui and parametrized log level
+    gui = LaunchConfiguration("gui")
+    log_level = LaunchConfiguration("log_level")
+
+    gui_arg = DeclareLaunchArgument(
+        name="gui", default_value="true", description="Whether to launch gzclient"
+    )
+
+    log_level_arg = DeclareLaunchArgument(
+        name="log_level",
+        default_value="2",
+        description="Gazebo log level: 0=quiet, 1=error, 2=warn, 3=info, 4=debug",
+    )
+
+    # Start Gazebo server
+    start_gazebo_server_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([ros_gz_sim, "launch", "gz_sim.launch.py"])
+        ),
+        # launch_arguments={'gz_args':['-u --verbose ', map_path],
+        #                  'on_exit_shutdown': 'true'}.items()
+        launch_arguments={
+            "gz_args": ["-r -s -v", log_level, " ", map_path],
+            "on_exit_shutdown": "true",
+        }.items(),
+    )
+
+    gzclient_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([ros_gz_sim, "launch", "gz_sim.launch.py"])
+        ),
+        launch_arguments={
+            "gz_args": [TextSubstitution(text="-g -v"), log_level]
+        }.items(),
+        condition=IfCondition(gui),
+    )
+
+    # Bridge clock and other global unique topics here
+    start_gazebo_ros_bridge_cmd = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        parameters=[
+            {"config_file": global_bridge_params},
+            {"expand_gz_topic_names": True},
+        ],
+        arguments=[
+            "--ros-args",
+        ],
+        output="screen",
+    )
+
+    # Create the launch description and populate
+    ld = LaunchDescription()
+    ld.add_action(gui_arg)
+    ld.add_action(log_level_arg)
+    ld.add_action(set_use_sim_time)
+    ld.add_action(set_env_vars_resources)
+    # Declare the launch options
+    ld.add_action(declare_map_cmd)
+    # Add any actions
+    ld.add_action(start_gazebo_server_cmd)
+    ld.add_action(gzclient_cmd)
+    # Bridging gz topics to ros
+    ld.add_action(start_gazebo_ros_bridge_cmd)
+
+    return ld

--- a/tests/examples/launch_examples/python_world.launch.py
+++ b/tests/examples/launch_examples/python_world.launch.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import (
+    AppendEnvironmentVariable,
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    GroupAction,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import (
+    LaunchConfiguration,
+    Command,
+    PathJoinSubstitution,
+    TextSubstitution,
+    PythonExpression,
+)
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.actions import Node, PushRosNamespace, SetParameter
+from launch_ros.parameter_descriptions import ParameterValue
+from launch.conditions import IfCondition, UnlessCondition
+
+
+def generate_launch_description():
+    # === Declare launch arguments ===
+    gui_arg = DeclareLaunchArgument(
+        name="gui", default_value="true", description="Whether to launch gzclient"
+    )
+
+    log_level_arg = DeclareLaunchArgument(
+        name="log_level",
+        default_value="2",
+        description="Gazebo log level: 0=quiet, 1=error, 2=warn, 3=info, 4=debug",
+    )
+
+    world_name_arg = DeclareLaunchArgument(
+        name="world_name",
+        default_value="empty.sdf",
+        description="Name of the world to load",
+    )
+
+    # === Load configurations ===
+    gui = LaunchConfiguration("gui")
+    log_level = LaunchConfiguration("log_level")
+    world_name = LaunchConfiguration("world_name")
+
+    world = PathJoinSubstitution(
+        [FindPackageShare("gazebo_robot_sim_athena"), "worlds", world_name]
+    )
+
+    ros_gz_sim = get_package_share_directory("ros_gz_sim")
+
+    global_bridge_params = os.path.join(
+        get_package_share_directory("gazebo_robot_sim_athena"),
+        "config",
+        "global_gazebo_bridge_params.yaml",
+    )
+
+    # === gzserver (headless physics engine) ===
+    gzserver_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(ros_gz_sim, "launch", "gz_sim.launch.py")
+        ),
+        launch_arguments={
+            "gz_args": [
+                TextSubstitution(text="-s -r -v"),
+                log_level,
+                TextSubstitution(text=" "),
+                world,
+            ],
+            "on_exit_shutdown": "true",
+        }.items(),
+    )
+
+    # === gzclient (conditionally started GUI) ===
+    gzclient_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(ros_gz_sim, "launch", "gz_sim.launch.py")
+        ),
+        launch_arguments={
+            "gz_args": [TextSubstitution(text="-g -v"), log_level]
+        }.items(),
+        condition=IfCondition(gui),
+    )
+
+    # === Bridge global topics ===
+    start_gazebo_ros_bridge_cmd = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        parameters=[
+            {"config_file": global_bridge_params},
+            {"expand_gz_topic_names": True},
+            {"namespace": "athena"},
+        ],
+        arguments=[
+            "--ros-args",
+            # '-p',
+            # f'config_file:={bridge_params}',
+        ],
+        output="screen",
+    )
+
+    # === Assemble LaunchDescription ===
+    ld = LaunchDescription()
+    ld.add_action(gui_arg)
+    ld.add_action(log_level_arg)
+    ld.add_action(world_name_arg)
+    ld.add_action(gzserver_cmd)
+    ld.add_action(gzclient_cmd)
+    ld.add_action(start_gazebo_ros_bridge_cmd)
+
+    return ld

--- a/tests/examples/launch_examples/xml_example.launch.xml
+++ b/tests/examples/launch_examples/xml_example.launch.xml
@@ -1,0 +1,51 @@
+<!-- from https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html -->
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <!-- args that can be set from the command line or a default will be used -->
+  <arg name="background_r" default="0" />
+  <arg name="background_g" default="255" />
+  <arg name="background_b" default="0" />
+  <arg name="chatter_py_ns" default="chatter/py/ns" />
+  <arg name="chatter_xml_ns" default="chatter/xml/ns" />
+  <arg name="chatter_yaml_ns" default="chatter/yaml/ns" />
+
+  <!-- include another launch file -->
+  <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py" />
+
+  <!-- include a Python launch file in the chatter_py_ns namespace-->
+  <group>
+    <!-- push_ros_namespace to set namespace of included nodes -->
+    <push_ros_namespace namespace="$(var chatter_py_ns)" />
+    <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py" />
+  </group>
+
+  <!-- include a xml launch file in the chatter_xml_ns namespace-->
+  <group>
+    <!-- push_ros_namespace to set namespace of included nodes -->
+    <push_ros_namespace namespace="$(var chatter_xml_ns)" />
+    <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.xml" />
+  </group>
+
+  <!-- include a yaml launch file in the chatter_yaml_ns namespace-->
+  <group>
+    <!-- push_ros_namespace to set namespace of included nodes -->
+    <push_ros_namespace namespace="$(var chatter_yaml_ns)" />
+    <include file="$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.yaml" />
+  </group>
+
+  <!-- start a turtlesim_node in the turtlesim1 namespace -->
+  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim1" />
+
+  <!-- start another turtlesim_node in the turtlesim2 namespace and use args to set parameters -->
+  <node pkg="turtlesim" exec="turtlesim_node" name="sim" namespace="turtlesim2">
+    <param name="background_r" value="$(var background_r)" />
+    <param name="background_g" value="$(var background_g)" />
+    <param name="background_b" value="$(var background_b)" />
+  </node>
+
+  <!-- perform remap so both turtles listen to the same command topic -->
+  <node pkg="turtlesim" exec="mimic" name="mimic">
+    <remap from="/input/pose" to="/turtlesim1/turtle1/pose" />
+    <remap from="/output/cmd_vel" to="/turtlesim2/turtle1/cmd_vel" />
+  </node>
+</launch>

--- a/tests/examples/launch_examples/yaml_example.launch.yml
+++ b/tests/examples/launch_examples/yaml_example.launch.yml
@@ -1,0 +1,80 @@
+%YAML 1.2
+# extracted from https://docs.ros.org/en/rolling/How-To-Guides/Launch-file-different-formats.html
+---
+launch:
+# args that can be set from the command line or a default will be used
+- arg:
+    name: "background_r"
+    default: "0"
+- arg:
+    name: "background_g"
+    default: "255"
+- arg:
+    name: "background_b"
+    default: "0"
+- arg:
+    name: "chatter_py_ns"
+    default: "chatter/py/ns"
+- arg:
+    name: "chatter_xml_ns"
+    default: "chatter/xml/ns"
+- arg:
+    name: "chatter_yaml_ns"
+    default: "chatter/yaml/ns"
+
+# include another launch file
+- include:
+    file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py"
+
+# include a Python launch file in the chatter_py_ns namespace
+- group:
+    - push_ros_namespace:
+        namespace: "$(var chatter_py_ns)"
+    - include:
+        file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.py"
+
+# include a xml launch file in the chatter_xml_ns namespace
+- group:
+    - push_ros_namespace:
+        namespace: "$(var chatter_xml_ns)"
+    - include:
+        file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.xml"
+
+# include a yaml launch file in the chatter_yaml_ns namespace
+- group:
+    - push_ros_namespace:
+        namespace: "$(var chatter_yaml_ns)"
+    - include:
+        file: "$(find-pkg-share demo_nodes_cpp)/launch/topics/talker_listener_launch.yaml"
+
+# start a turtlesim_node in the turtlesim1 namespace
+- node:
+    pkg: "turtlesim"
+    exec: "turtlesim_node"
+    name: "sim"
+    namespace: "turtlesim1"
+
+# start another turtlesim_node in the turtlesim2 namespace and use args to set parameters
+- node:
+    pkg: "turtlesim"
+    exec: "turtlesim_node"
+    name: "sim"
+    namespace: "turtlesim2"
+    param:
+    - name: "background_r"
+      value: "$(var background_r)"
+    - name: "background_g"
+      value: "$(var background_g)"
+    - name: "background_b"
+      value: "$(var background_b)"
+
+# perform remap so both turtles listen to the same command topic
+- node:
+    pkg: "turtlesim"
+    exec: "mimic"
+    name: "mimic"
+    remap:
+    - from: "/input/pose"
+      to: "/turtlesim1/turtle1/pose"
+    - from: "/output/cmd_vel"
+      to: "/turtlesim2/turtle1/cmd_vel"

--- a/tests/test_find_launch_dependencies.py
+++ b/tests/test_find_launch_dependencies.py
@@ -1,0 +1,48 @@
+import os
+import unittest
+
+from package_xml_validation.helpers.find_launch_dependencies import scan_file
+
+
+class TestFindLaunchDependencies(unittest.TestCase):
+    # ─── Define test cases: filename → expected packages ───
+    EXAMPLES = {
+        "python_example.launch.py": ["demo_nodes_cpp", "turtlesim"],
+        "xml_example.launch.xml": ["demo_nodes_cpp", "turtlesim"],
+        "yaml_example.launch.yml": ["demo_nodes_cpp", "turtlesim"],
+        "hector_launch_component.yaml": ["athena_announcer"],
+        "python_world.launch.py": [
+            "gazebo_robot_sim_athena",
+            "ros_gz_sim",
+            "ros_gz_bridge",
+        ],
+    }
+
+    # Directory where example launch files live
+    BASE_DIR = os.path.join(os.path.dirname(__file__), "examples", "launch_examples")
+
+    def test_scan_each_file(self):
+        """Ensure scan_file finds exactly the expected packages in each example."""
+        for filename, expected_pkgs in self.EXAMPLES.items():
+            with self.subTest(filename=filename):
+                path = os.path.join(self.BASE_DIR, filename)
+                # 1) file must exist
+                self.assertTrue(os.path.isfile(path), f"Example file not found: {path}")
+                # 2) scan it
+                found = set()
+                print(f"Scanning {path} for launch dependencies...")
+                scan_file(path, found)
+                # 3) compare sets
+                self.assertEqual(
+                    set(expected_pkgs),
+                    found,
+                    msg=(
+                        f"For '{filename}':\n"
+                        f"  expected: {sorted(expected_pkgs)}\n"
+                        f"  found:    {sorted(found)}"
+                    ),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_find_launch_dependencies.py
+++ b/tests/test_find_launch_dependencies.py
@@ -16,6 +16,11 @@ class TestFindLaunchDependencies(unittest.TestCase):
             "ros_gz_sim",
             "ros_gz_bridge",
         ],
+        "python_gazebo_launch.py": [
+            "simulation_scenario_robocup_gazebo",
+            "ros_gz_sim",
+            "ros_gz_bridge",
+        ],
     }
 
     # Directory where example launch files live


### PR DESCRIPTION
## Overview
Introduce a new validator that scans ROS 2 launch files (.py, .yaml, .xml) for any referenced packages and ensures each appears in package.xml as either an `<exec_depend>` or `<depend>`.

## Behavior

 Parses all `.yaml, .yml, .py,  .xml, .launch` files under `<package_path/launch` and `<package_path/components>`, extracts package names via regex, and reports any missing compared to the exec dependencies in the `package.xml`.

   If not Check-Only Mode: Automatically inserts any missing packages into the <exec_depend> section of package.xml, maintaining alphabetical order.

This ensures that every package used in launch configurations is properly declared before runtime.