### PR TITLE
Feature/ignore deps

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -105,7 +105,7 @@ This tool enforces the standard ROS 2 element order:
 ### 2. Dependency Integrity
 
 * **Launch File Scanning:** Scans `.py`, `.yaml`, and `.xml` launch files. If a package is used in a launch file but missing from `package.xml`, it adds it as an `<exec_depend>` or `<test_depend>`.
-* **CMake Synchronization:** Compares `package.xml` against `CMakeLists.txt` to ensure build dependencies match. It adds missing as `<depend>` or `<test_depend>`.
+* **CMake Synchronization:** Compares `package.xml` against `CMakeLists.txt` to ensure build dependencies match. It adds missing as `<depend>` or `<test_depend>`. Optional lookups of the form `find_package(<pkg> QUIET)` are treated as optional and are not enforced in `package.xml`.
 * **Rosdep Validation:** Verifies that your dependency names exist as valid keys in the rosdep database.
 
 ### 3. Build Configuration
@@ -156,6 +156,7 @@ package-xml-validator . --compare-with-cmake --auto-fill-missing-deps
 | `--skip-rosdep-key-validation` | Skip verifying if dependency names exist in the `rosdep` database. |
 | `--missing-deps-only` | Skips formatting checks; only looks for missing dependencies. |
 | `--ignore-deps dep1,dep2` | Comma-separated list of dependency names to globally ignore in validation. |
+| `--skip-launch-dep-check` | Skip checking for missing dependencies in launch and test files. |
 
 ---
 

--- a/Readme.md
+++ b/Readme.md
@@ -104,8 +104,8 @@ This tool enforces the standard ROS 2 element order:
 
 ### 2. Dependency Integrity
 
-* **Launch File Scanning:** Scans `.py`, `.yaml`, and `.xml` launch files. If a package is used in a launch file but missing from `package.xml`, it adds it as an `<exec_depend>` or `<test_depend>`.
-* **CMake Synchronization:** Compares `package.xml` against `CMakeLists.txt` to ensure build dependencies match. It adds missing as `<depend>` or `<test_depend>`. Optional lookups of the form `find_package(<pkg> QUIET)` are treated as optional and are not enforced in `package.xml`.
+* **Launch File Scanning:** Scans `.py`, `.yaml`, and `.xml` launch files. If a package is used in a launch file but missing from `package.xml`, it adds it as an `<exec_depend>` or `<test_depend>`. Can be disabled with `--skip-launch-dep-check` when launch scanning produces false positives or is not desired for a given package.
+* **CMake Synchronization:** Compares `package.xml` against `CMakeLists.txt` to ensure build dependencies match, adding missing entries as `<depend>` or `<test_depend>`. Calls of the form `find_package(<pkg> QUIET)` (with `QUIET` and no `REQUIRED`) are treated as optional and skipped; all other forms — `find_package(<pkg>)`, `find_package(<pkg> REQUIRED)`, and `find_package(<pkg> REQUIRED QUIET)` — are enforced in `package.xml`.
 * **Rosdep Validation:** Verifies that your dependency names exist as valid keys in the rosdep database.
 
 ### 3. Build Configuration

--- a/Readme.md
+++ b/Readme.md
@@ -155,6 +155,43 @@ package-xml-validator . --compare-with-cmake --auto-fill-missing-deps
 | `--strict-cmake-checking` | Treat unresolved CMake dependencies as errors instead of warnings. |
 | `--skip-rosdep-key-validation` | Skip verifying if dependency names exist in the `rosdep` database. |
 | `--missing-deps-only` | Skips formatting checks; only looks for missing dependencies. |
+| `--ignore-deps dep1,dep2` | Comma-separated list of dependency names to globally ignore in validation. |
+
+---
+
+## Ignoring Dependencies
+
+Sometimes a dependency is detected in your code (CMakeLists.txt or launch files) but you intentionally do not want to declare it in `package.xml`. This can happen when a package pulls in heavy transitive dependencies (e.g., `rviz2`) that should not be installed on every target machine.
+
+> **Recommended approach:** Split your package into two. For example, instead of a single `robot_description` package that contains both URDF/xacro files *and* an RViz visualization launch file, create:
+> - `robot_description` — contains the model files and their dependencies
+> - `robot_description_visualization` — contains launch files for RViz, joint_state_publisher_gui, etc.
+>
+> This way each package only declares the dependencies it truly needs, and deploying `robot_description` to a robot won't pull in `rviz2` and all its GUI dependencies.
+
+If restructuring is not practical, you can suppress specific missing dependency errors using an XML comment directive directly in your `package.xml`:
+
+```xml
+<package format="3">
+  <name>robot_description</name>
+  <!-- ... -->
+
+  <!-- validator:ignore rviz2 joint_state_publisher_gui -->
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <!-- ... -->
+</package>
+```
+
+- List space-separated dependency names after `validator:ignore`
+- Multiple `<!-- validator:ignore ... -->` comments are allowed and will be merged
+- Ignored dependencies will not be flagged as missing and will not be auto-filled
+
+For a global override (e.g., in CI), use the `--ignore-deps` CLI argument:
+
+```bash
+package-xml-validator . --compare-with-cmake --ignore-deps rviz2,joint_state_publisher_gui
+```
 
 ---
 

--- a/Readme.md
+++ b/Readme.md
@@ -162,15 +162,11 @@ package-xml-validator . --compare-with-cmake --auto-fill-missing-deps
 
 ## Ignoring Dependencies
 
-Sometimes a dependency is detected in your code (CMakeLists.txt or launch files) but you intentionally do not want to declare it in `package.xml`. This can happen when a package pulls in heavy transitive dependencies (e.g., `rviz2`) that should not be installed on every target machine.
+Some dependencies detected in `CMakeLists.txt` or launch files should not be declared in `package.xml` — typically when a package pulls in heavy transitive dependencies (e.g. `rviz2` and its GUI stack) that should not be installed on every target machine.
 
-> **Recommended approach:** Split your package into two. For example, instead of a single `robot_description` package that contains both URDF/xacro files *and* an RViz visualization launch file, create:
-> - `robot_description` — contains the model files and their dependencies
-> - `robot_description_visualization` — contains launch files for RViz, joint_state_publisher_gui, etc.
->
-> This way each package only declares the dependencies it truly needs, and deploying `robot_description` to a robot won't pull in `rviz2` and all its GUI dependencies.
+> **Prefer splitting the package first.** For example, rather than a single `robot_description` package containing both URDF/xacro files *and* an RViz visualization launch file, split it into `robot_description` (model files) and `robot_description_visualization` (RViz launch files). Each package then declares only what it truly needs, and deploying `robot_description` to a robot won't drag in `rviz2`.
 
-If restructuring is not practical, you can suppress specific missing dependency errors using an XML comment directive directly in your `package.xml`:
+If splitting is not practical, the tool recognizes a `validator:ignore` directive inside XML comments:
 
 ```xml
 <package format="3">
@@ -184,11 +180,12 @@ If restructuring is not practical, you can suppress specific missing dependency 
 </package>
 ```
 
-- List space-separated dependency names after `validator:ignore`
-- Multiple `<!-- validator:ignore ... -->` comments are allowed and will be merged
-- Ignored dependencies will not be flagged as missing and will not be auto-filled
+- Names are space-separated after `validator:ignore`.
+- The directive may appear anywhere inside the `<package>` element; multiple directives in the same file are merged.
+- Listed dependencies are neither flagged as missing nor added by `--auto-fill-missing-deps`.
+- Scope is per-file — each `package.xml` manages its own ignore list.
 
-For a global override (e.g., in CI), use the `--ignore-deps` CLI argument:
+For a global override — typically in CI — use the `--ignore-deps` CLI argument:
 
 ```bash
 package-xml-validator . --compare-with-cmake --ignore-deps rviz2,joint_state_publisher_gui

--- a/package_xml_validation/helpers/cmake_parsers.py
+++ b/package_xml_validation/helpers/cmake_parsers.py
@@ -256,6 +256,13 @@ def retrieve_cmake_dependencies(
             inside = fp_match.group(1)
             expanded_tokens = inside.split()
 
+            # Optional lookup: QUIET without REQUIRED means the build does not
+            # fail if the package is missing, so it should not be enforced in
+            # package.xml.
+            upper_tokens = {tok.upper() for tok in expanded_tokens}
+            if "QUIET" in upper_tokens and "REQUIRED" not in upper_tokens:
+                continue
+
             # 1. Truncate at the first Stop Token (e.g., COMPONENTS)
             #    find_package(Pkg 1.0 REQUIRED COMPONENTS a b) -> [Pkg, 1.0, REQUIRED]
             cut_index = len(expanded_tokens)

--- a/package_xml_validation/helpers/exception_parser.py
+++ b/package_xml_validation/helpers/exception_parser.py
@@ -1,0 +1,59 @@
+"""Parse validator exception directives from XML comments in package.xml."""
+
+import re
+from dataclasses import dataclass, field
+
+import lxml.etree as ET
+
+# Regex pattern for parsing validator:ignore directives
+_IGNORE_DEPS_PATTERN = re.compile(r"validator:ignore\s+(.+)")
+
+
+@dataclass(frozen=True)
+class DependencyExceptions:
+    """Holds per-package dependency exceptions parsed from XML comments."""
+
+    ignored_deps: frozenset[str] = field(default_factory=frozenset)
+
+    def is_ignored(self, dep_name: str) -> bool:
+        """Check whether a dependency should be excluded from validation.
+
+        Args:
+            dep_name: The dependency name (e.g., 'rclpy').
+
+        Returns:
+            True if the dependency should be skipped.
+
+        """
+        return dep_name in self.ignored_deps
+
+
+def parse_exceptions(root) -> DependencyExceptions:
+    """Parse validator:ignore directives from XML comments in package.xml.
+
+    Scans all direct children of the root element for comments matching
+    the pattern ``<!-- validator:ignore dep1 dep2 ... -->``. Multiple
+    such comments are allowed and their dependency lists are merged.
+
+    Args:
+        root: lxml root element of package.xml.
+
+    Returns:
+        DependencyExceptions containing all parsed exceptions.
+
+    """
+    ignored_deps: set[str] = set()
+
+    for node in root:
+        if not callable(node.tag):
+            continue
+        if node.tag is not ET.Comment:
+            continue
+
+        text = node.text.strip() if node.text else ""
+        match = _IGNORE_DEPS_PATTERN.match(text)
+        if match:
+            deps = match.group(1).split()
+            ignored_deps.update(deps)
+
+    return DependencyExceptions(ignored_deps=frozenset(ignored_deps))

--- a/package_xml_validation/helpers/validation_steps.py
+++ b/package_xml_validation/helpers/validation_steps.py
@@ -17,6 +17,7 @@ class ValidationConfig:
     strict_cmake_checking: bool
     missing_deps_only: bool
     ignore_formatting_errors: bool
+    skip_launch_dep_check: bool = False
 
 
 @dataclass
@@ -657,6 +658,8 @@ class LaunchDependencyStep(ValidationStep):
 
         """
         result = ValidationResult(root=root)
+        if self.config.skip_launch_dep_check:
+            return result
 
         def extract_launch_deps(folder_names: list[str]) -> list[str]:
             """Extract launch dependencies from listed folders.

--- a/package_xml_validation/helpers/validation_steps.py
+++ b/package_xml_validation/helpers/validation_steps.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import Callable
 
 from .cmake_parsers import read_deps_from_cmake_file
+from .exception_parser import DependencyExceptions
 from .find_launch_dependencies import scan_files
 from .package_types import PackageType, get_package_type
 
@@ -443,13 +444,16 @@ class RosdepCheckStep(ValidationStep):
 class CMakeComparisonStep(ValidationStep):
     name = "CMake dependency comparison"
 
-    def __init__(self, config: ValidationConfig, formatter, rosdep_validator):
+    def __init__(
+        self, config: ValidationConfig, formatter, rosdep_validator, exceptions=None
+    ):
         """Initialize CMake comparison validation step.
 
         Args:
             config: ValidationConfig with feature flags.
             formatter: PackageXmlFormatter instance.
             rosdep_validator: RosdepValidator instance.
+            exceptions: DependencyExceptions for per-package ignored deps.
 
         Returns:
             None.
@@ -458,6 +462,7 @@ class CMakeComparisonStep(ValidationStep):
         super().__init__(config)
         self.formatter = formatter
         self.rosdep_validator = rosdep_validator
+        self.exceptions = exceptions or DependencyExceptions()
 
     def perform_check(self, root, xml_file: str) -> ValidationResult:
         """Compare CMakeLists.txt dependencies to package.xml entries.
@@ -552,6 +557,16 @@ class CMakeComparisonStep(ValidationStep):
                     continue
                 unresolved_deps.append((dep, candidates))
 
+            # Filter out excepted dependencies
+            missing_deps = [
+                dep for dep in missing_deps if not self.exceptions.is_ignored(dep)
+            ]
+            unresolved_deps = [
+                (dep, candidates)
+                for dep, candidates in unresolved_deps
+                if not self.exceptions.is_ignored(dep)
+            ]
+
             if missing_deps:
                 deps = "\n\t\t" + "\n\t\t".join(dedupe_dependencies(missing_deps))
                 if self.config.check_only or not self.config.auto_fill_missing_deps:
@@ -605,6 +620,7 @@ class LaunchDependencyStep(ValidationStep):
         package_name: str,
         exec_deps: list[str],
         test_deps: list[str],
+        exceptions=None,
     ):
         """Initialize launch dependency validation step.
 
@@ -615,6 +631,7 @@ class LaunchDependencyStep(ValidationStep):
             package_name: Name of the package being checked.
             exec_deps: Existing exec dependencies from package.xml.
             test_deps: Existing test dependencies from package.xml.
+            exceptions: DependencyExceptions for per-package ignored deps.
 
         Returns:
             None.
@@ -626,6 +643,7 @@ class LaunchDependencyStep(ValidationStep):
         self.package_name = package_name
         self.exec_deps = exec_deps
         self.test_deps = test_deps
+        self.exceptions = exceptions or DependencyExceptions()
 
     def perform_check(self, root, xml_file: str) -> ValidationResult:
         """Validate launch/test file dependencies against package.xml.
@@ -678,7 +696,9 @@ class LaunchDependencyStep(ValidationStep):
             missing_deps = [
                 dep
                 for dep in launch_deps
-                if dep not in xml_deps and dep != self.package_name
+                if dep not in xml_deps
+                and dep != self.package_name
+                and not self.exceptions.is_ignored(dep)
             ]
             if not missing_deps:
                 return

--- a/package_xml_validation/package_xml_validator.py
+++ b/package_xml_validation/package_xml_validator.py
@@ -53,6 +53,7 @@ class PackageXmlValidator:
         path=None,
         verbose=False,
         ignored_deps=None,
+        skip_launch_dep_check=False,
     ):
         """Initialize the package.xml validator with feature flags.
 
@@ -67,6 +68,7 @@ class PackageXmlValidator:
             path: Path used for workspace discovery in rosdep validation.
             verbose: Enable verbose logging.
             ignored_deps: Global set of dependency names to ignore in validation.
+            skip_launch_dep_check: Skip launch and test file dependency checks.
 
         Returns:
             None.
@@ -104,6 +106,7 @@ class PackageXmlValidator:
             strict_cmake_checking=self.strict_cmake_checking,
             missing_deps_only=self.missing_deps_only,
             ignore_formatting_errors=self.ignore_formatting_errors,
+            skip_launch_dep_check=skip_launch_dep_check,
         )
         self.encountered_unresolvable_error = False
 
@@ -392,6 +395,12 @@ def main():
         help="Comma-separated list of dependency names to globally ignore in validation.",
     )
 
+    parser.add_argument(
+        "--skip-launch-dep-check",
+        action="store_true",
+        help="Skip checking for missing dependencies in launch and test files.",
+    )
+
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
@@ -430,6 +439,7 @@ def main():
         ignore_formatting_errors=args.ignore_formatting_errors,
         path=args.file if args.file else args.src[0],
         ignored_deps=global_ignored,
+        skip_launch_dep_check=args.skip_launch_dep_check,
     )
 
     if args.file:

--- a/package_xml_validation/package_xml_validator.py
+++ b/package_xml_validation/package_xml_validator.py
@@ -7,6 +7,7 @@ import lxml.etree as ET
 import argcomplete
 
 try:
+    from .helpers.exception_parser import DependencyExceptions, parse_exceptions
     from .helpers.logger import get_logger
     from .helpers.rosdep_validator import RosdepValidator
     from .helpers.pkg_xml_formatter import PackageXmlFormatter
@@ -22,6 +23,7 @@ try:
     )
     from .helpers.workspace import find_package_xml_files
 except ImportError:
+    from helpers.exception_parser import DependencyExceptions, parse_exceptions
     from helpers.logger import get_logger
     from helpers.rosdep_validator import RosdepValidator
     from helpers.pkg_xml_formatter import PackageXmlFormatter
@@ -50,6 +52,7 @@ class PackageXmlValidator:
         ignore_formatting_errors=False,
         path=None,
         verbose=False,
+        ignored_deps=None,
     ):
         """Initialize the package.xml validator with feature flags.
 
@@ -63,12 +66,16 @@ class PackageXmlValidator:
             ignore_formatting_errors: Skip formatting-only checks.
             path: Path used for workspace discovery in rosdep validation.
             verbose: Enable verbose logging.
+            ignored_deps: Global set of dependency names to ignore in validation.
 
         Returns:
             None.
 
         """
         self.verbose = verbose
+        self.global_ignored_deps = (
+            frozenset(ignored_deps) if ignored_deps else frozenset()
+        )
         self.missing_deps_only = missing_deps_only
         self.ignore_formatting_errors = ignore_formatting_errors
         self.check_only = check_only or missing_deps_only or ignore_formatting_errors
@@ -167,6 +174,12 @@ class PackageXmlValidator:
         exec_deps = self.formatter.retrieve_exec_dependencies(root)
         test_deps = self.formatter.retrieve_test_dependencies(root)
 
+        # Parse per-package exceptions from XML comments and merge with global
+        exceptions = parse_exceptions(root)
+        if self.global_ignored_deps:
+            merged = exceptions.ignored_deps | self.global_ignored_deps
+            exceptions = DependencyExceptions(ignored_deps=merged)
+
         steps = [
             FormatterValidationStep(self.validation_config, self.formatter),
             LaunchDependencyStep(
@@ -176,6 +189,7 @@ class PackageXmlValidator:
                 package_name,
                 exec_deps,
                 test_deps,
+                exceptions,
             ),
         ]
 
@@ -198,7 +212,10 @@ class PackageXmlValidator:
         if self.compare_with_cmake:
             steps.append(
                 CMakeComparisonStep(
-                    self.validation_config, self.formatter, self.rosdep_validator
+                    self.validation_config,
+                    self.formatter,
+                    self.rosdep_validator,
+                    exceptions,
                 )
             )
 
@@ -368,6 +385,13 @@ def main():
         help="Treat unresolved CMake dependencies as errors instead of warnings.",
     )
 
+    parser.add_argument(
+        "--ignore-deps",
+        type=str,
+        default="",
+        help="Comma-separated list of dependency names to globally ignore in validation.",
+    )
+
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
@@ -387,6 +411,12 @@ def main():
         print("Cannot use --compare-with-cmake with --skip-rosdep-key-validation.")
         args.compare_with_cmake = False
 
+    global_ignored = (
+        [d.strip() for d in args.ignore_deps.split(",") if d.strip()]
+        if args.ignore_deps
+        else []
+    )
+
     formatter = PackageXmlValidator(
         check_only=args.check_only
         or args.missing_deps_only
@@ -399,6 +429,7 @@ def main():
         missing_deps_only=args.missing_deps_only,
         ignore_formatting_errors=args.ignore_formatting_errors,
         path=args.file if args.file else args.src[0],
+        ignored_deps=global_ignored,
     )
 
     if args.file:

--- a/tests/data/cmake_examples/common_patterns/CMakeLists.txt
+++ b/tests/data/cmake_examples/common_patterns/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(
   REQUIRED
 )
 find_package(Python3 3.10 QUIET)
+find_package(benchmark QUIET)
+find_package(fastcdr REQUIRED QUIET)
 find_package(OpenMP REQUIRED)
 find_package(Threads REQUIRED)
 

--- a/tests/examples/cmake_specific_tests/quiet_find_package/pkg_correct/CMakeLists.txt
+++ b/tests/examples/cmake_specific_tests/quiet_find_package/pkg_correct/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+project(quiet_find_package)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(benchmark QUIET)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+endif()
+
+ament_package()

--- a/tests/examples/cmake_specific_tests/quiet_find_package/pkg_correct/package.xml
+++ b/tests/examples/cmake_specific_tests/quiet_find_package/pkg_correct/package.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>quiet_find_package</name>
+  <version>0.0.0</version>
+  <description>Fixture verifying QUIET find_package calls are not enforced in package.xml.</description>
+  <maintainer email="test@example.com">Test</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/examples/exception_tests/cmake_exceptions/pkg_with_exception/CMakeLists.txt
+++ b/tests/examples/exception_tests/cmake_exceptions/pkg_with_exception/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_pkg)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(urdf REQUIRED)
+
+ament_package()

--- a/tests/examples/exception_tests/cmake_exceptions/pkg_with_exception/package.xml
+++ b/tests/examples/exception_tests/cmake_exceptions/pkg_with_exception/package.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<package format="3">
+  <name>test_pkg</name>
+  <version>0.0.0</version>
+  <description>Test package for exception testing</description>
+  <maintainer email="test@test.com">Test</maintainer>
+  <license>MIT</license>
+
+  <!-- validator:ignore urdf -->
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/examples/exception_tests/cmake_exceptions/pkg_without_exception/CMakeLists.txt
+++ b/tests/examples/exception_tests/cmake_exceptions/pkg_without_exception/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_pkg)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(urdf REQUIRED)
+
+ament_package()

--- a/tests/examples/exception_tests/cmake_exceptions/pkg_without_exception/package.xml
+++ b/tests/examples/exception_tests/cmake_exceptions/pkg_without_exception/package.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<package format="3">
+  <name>test_pkg</name>
+  <version>0.0.0</version>
+  <description>Test package for exception testing</description>
+  <maintainer email="test@test.com">Test</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/examples/exception_tests/launch_exceptions/pkg_with_exception/CMakeLists.txt
+++ b/tests/examples/exception_tests/launch_exceptions/pkg_with_exception/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
+project(launch_test_pkg)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/tests/examples/exception_tests/launch_exceptions/pkg_with_exception/launch/example.launch.py
+++ b/tests/examples/exception_tests/launch_exceptions/pkg_with_exception/launch/example.launch.py
@@ -1,0 +1,13 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            Node(
+                package="robot_state_publisher",
+                executable="robot_state_publisher",
+            ),
+        ]
+    )

--- a/tests/examples/exception_tests/launch_exceptions/pkg_with_exception/package.xml
+++ b/tests/examples/exception_tests/launch_exceptions/pkg_with_exception/package.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<package format="3">
+  <name>launch_test_pkg</name>
+  <version>0.0.0</version>
+  <description>Test package for launch exception testing</description>
+  <maintainer email="test@test.com">Test</maintainer>
+  <license>MIT</license>
+
+  <!-- validator:ignore robot_state_publisher -->
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/examples/exception_tests/launch_exceptions/pkg_without_exception/CMakeLists.txt
+++ b/tests/examples/exception_tests/launch_exceptions/pkg_without_exception/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
+project(launch_test_pkg)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/tests/examples/exception_tests/launch_exceptions/pkg_without_exception/launch/example.launch.py
+++ b/tests/examples/exception_tests/launch_exceptions/pkg_without_exception/launch/example.launch.py
@@ -1,0 +1,13 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            Node(
+                package="robot_state_publisher",
+                executable="robot_state_publisher",
+            ),
+        ]
+    )

--- a/tests/examples/exception_tests/launch_exceptions/pkg_without_exception/package.xml
+++ b/tests/examples/exception_tests/launch_exceptions/pkg_without_exception/package.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<package format="3">
+  <name>launch_test_pkg</name>
+  <version>0.0.0</version>
+  <description>Test package for launch exception testing</description>
+  <maintainer email="test@test.com">Test</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/tests/test_cmake_parser.py
+++ b/tests/test_cmake_parser.py
@@ -61,12 +61,12 @@ class TestCMakeParser(unittest.TestCase):
                     "Qt5",
                     "Eigen3",
                     "yaml-cpp",
-                    "Python3",
+                    "fastcdr",
                     "fmt",
                     "spdlog",
                 ],
                 "test": ["ament_cmake_gtest", "benchmark"],
-                "absent": ["OpenMP", "Threads", "ament_cmake"],
+                "absent": ["OpenMP", "Threads", "ament_cmake", "Python3"],
             },
         }
 

--- a/tests/test_dependency_exceptions.py
+++ b/tests/test_dependency_exceptions.py
@@ -1,0 +1,215 @@
+import os
+import unittest
+import tempfile
+import shutil
+from unittest.mock import MagicMock
+
+import lxml.etree as ET
+
+from package_xml_validation.helpers.exception_parser import (
+    DependencyExceptions,
+    parse_exceptions,
+)
+from package_xml_validation.package_xml_validator import PackageXmlValidator
+
+
+class TestParseExceptions(unittest.TestCase):
+    """Unit tests for the exception_parser module."""
+
+    def _make_root(self, xml_str: str):
+        return ET.fromstring(xml_str)
+
+    def test_no_comments(self):
+        root = self._make_root('<package format="3"><name>test</name></package>')
+        exceptions = parse_exceptions(root)
+        self.assertEqual(exceptions.ignored_deps, frozenset())
+
+    def test_single_ignore_comment(self):
+        root = self._make_root(
+            '<package format="3">'
+            "<!-- validator:ignore rclpy -->"
+            "<name>test</name>"
+            "</package>"
+        )
+        exceptions = parse_exceptions(root)
+        self.assertEqual(exceptions.ignored_deps, frozenset({"rclpy"}))
+
+    def test_multiple_deps_in_one_comment(self):
+        root = self._make_root(
+            '<package format="3">'
+            "<!-- validator:ignore rclpy ament_lint_auto sensor_msgs -->"
+            "<name>test</name>"
+            "</package>"
+        )
+        exceptions = parse_exceptions(root)
+        self.assertEqual(
+            exceptions.ignored_deps,
+            frozenset({"rclpy", "ament_lint_auto", "sensor_msgs"}),
+        )
+
+    def test_multiple_ignore_comments_merged(self):
+        root = self._make_root(
+            '<package format="3">'
+            "<!-- validator:ignore rclpy -->"
+            "<!-- validator:ignore sensor_msgs -->"
+            "<name>test</name>"
+            "</package>"
+        )
+        exceptions = parse_exceptions(root)
+        self.assertEqual(exceptions.ignored_deps, frozenset({"rclpy", "sensor_msgs"}))
+
+    def test_non_matching_comments_ignored(self):
+        root = self._make_root(
+            '<package format="3">'
+            "<!-- This is a regular comment -->"
+            "<!-- validator:ignore rclpy -->"
+            "<!-- Another comment -->"
+            "<name>test</name>"
+            "</package>"
+        )
+        exceptions = parse_exceptions(root)
+        self.assertEqual(exceptions.ignored_deps, frozenset({"rclpy"}))
+
+    def test_empty_ignore_directive(self):
+        """validator:ignore with no deps should produce empty set."""
+        root = self._make_root(
+            '<package format="3"><!-- validator:ignore --><name>test</name></package>'
+        )
+        exceptions = parse_exceptions(root)
+        self.assertEqual(exceptions.ignored_deps, frozenset())
+
+
+class TestDependencyExceptions(unittest.TestCase):
+    """Unit tests for the DependencyExceptions dataclass."""
+
+    def test_is_ignored_match(self):
+        exc = DependencyExceptions(ignored_deps=frozenset({"rclpy", "sensor_msgs"}))
+        self.assertTrue(exc.is_ignored("rclpy"))
+        self.assertTrue(exc.is_ignored("sensor_msgs"))
+
+    def test_is_ignored_no_match(self):
+        exc = DependencyExceptions(ignored_deps=frozenset({"rclpy"}))
+        self.assertFalse(exc.is_ignored("sensor_msgs"))
+
+    def test_empty_exceptions(self):
+        exc = DependencyExceptions()
+        self.assertFalse(exc.is_ignored("anything"))
+
+
+class TestCMakeComparisonWithExceptions(unittest.TestCase):
+    """Integration test: CMake comparison step respects validator:ignore comments."""
+
+    @classmethod
+    def setUpClass(cls):
+        current_dir = os.path.dirname(__file__)
+        cls.examples_dir = os.path.join(
+            current_dir, "examples", "exception_tests", "cmake_exceptions"
+        )
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="xml_exception_tests_")
+        shutil.copytree(self.examples_dir, self.test_dir, dirs_exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def _make_validator(self, **kwargs):
+        validator = PackageXmlValidator(
+            check_only=kwargs.get("check_only", True),
+            verbose=True,
+            auto_fill_missing_deps=kwargs.get("auto_fill_missing_deps", False),
+            check_rosdeps=True,
+            compare_with_cmake=True,
+        )
+        validator.rosdep_validator = MagicMock()
+        validator.rosdep_validator.check_rosdeps_and_local_pkgs.return_value = []
+        validator.rosdep_validator.resolve_cmake_dependency.side_effect = lambda x: x
+        return validator
+
+    def test_ignored_dep_not_flagged(self):
+        """A package.xml with validator:ignore for the missing dep should pass."""
+        xml_file = os.path.join(self.test_dir, "pkg_with_exception", "package.xml")
+        validator = self._make_validator(check_only=True)
+        valid = validator.check_and_format_files([xml_file])
+        self.assertTrue(valid, "Package with validator:ignore should pass validation.")
+
+    def test_without_exception_fails(self):
+        """Same package without the ignore comment should fail."""
+        xml_file = os.path.join(self.test_dir, "pkg_without_exception", "package.xml")
+        validator = self._make_validator(check_only=True)
+        valid = validator.check_and_format_files([xml_file])
+        self.assertFalse(
+            valid, "Package without validator:ignore should fail validation."
+        )
+
+    def test_global_ignore_deps_cli(self):
+        """The --ignore-deps CLI argument should suppress the missing dep error."""
+        xml_file = os.path.join(self.test_dir, "pkg_without_exception", "package.xml")
+        validator = self._make_validator(check_only=True)
+        # Simulate --ignore-deps urdf
+        validator.global_ignored_deps = frozenset({"urdf"})
+        valid = validator.check_and_format_files([xml_file])
+        self.assertTrue(valid, "Global --ignore-deps should suppress the missing dep.")
+
+    def test_auto_fill_skips_ignored_deps(self):
+        """Auto-fill should not add ignored dependencies."""
+        xml_file = os.path.join(self.test_dir, "pkg_with_exception", "package.xml")
+
+        validator = self._make_validator(check_only=False, auto_fill_missing_deps=True)
+        validator.check_and_format_files([xml_file])
+
+        with open(xml_file) as f:
+            updated_content = f.read()
+
+        # The ignored dep (urdf) should NOT have been added
+        self.assertNotIn("<depend>urdf</depend>", updated_content)
+
+
+class TestLaunchDepsWithExceptions(unittest.TestCase):
+    """Integration test: Launch dependency step respects validator:ignore comments."""
+
+    @classmethod
+    def setUpClass(cls):
+        current_dir = os.path.dirname(__file__)
+        cls.examples_dir = os.path.join(
+            current_dir, "examples", "exception_tests", "launch_exceptions"
+        )
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="xml_launch_exception_tests_")
+        shutil.copytree(self.examples_dir, self.test_dir, dirs_exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def _make_validator(self, **kwargs):
+        validator = PackageXmlValidator(
+            check_only=kwargs.get("check_only", True),
+            verbose=True,
+            auto_fill_missing_deps=kwargs.get("auto_fill_missing_deps", False),
+            check_rosdeps=True,
+            compare_with_cmake=False,
+        )
+        validator.rosdep_validator = MagicMock()
+        validator.rosdep_validator.check_rosdeps_and_local_pkgs.return_value = []
+        return validator
+
+    def test_ignored_launch_dep_not_flagged(self):
+        """A package.xml with validator:ignore for a launch dep should pass."""
+        xml_file = os.path.join(self.test_dir, "pkg_with_exception", "package.xml")
+        validator = self._make_validator(check_only=True)
+        valid = validator.check_and_format_files([xml_file])
+        self.assertTrue(
+            valid, "Package with validator:ignore for launch dep should pass."
+        )
+
+    def test_without_exception_fails(self):
+        """Same package without the ignore comment should fail."""
+        xml_file = os.path.join(self.test_dir, "pkg_without_exception", "package.xml")
+        validator = self._make_validator(check_only=True)
+        valid = validator.check_and_format_files([xml_file])
+        self.assertFalse(valid, "Package without validator:ignore should fail.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pkg_missing_launch_deps.py
+++ b/tests/test_pkg_missing_launch_deps.py
@@ -177,6 +177,54 @@ class TestPackageXmlValidator(unittest.TestCase):
                     print(f"->   {line1.rstrip()} != {line2.rstrip()}")
         return result
 
+    def test_skip_launch_dep_check_silences_missing_launch_and_test_deps(self):
+        """With skip_launch_dep_check=True, packages that are only invalid due to
+        missing launch/test file dependencies should validate as correct and the
+        package.xml should be left untouched."""
+        formatter = PackageXmlValidator(
+            check_only=False,
+            verbose=True,
+            auto_fill_missing_deps=True,
+            check_rosdeps=True,
+            compare_with_cmake=True,
+            skip_launch_dep_check=True,
+        )
+        formatter.rosdep_validator = MagicMock()
+        formatter.rosdep_validator.resolve_cmake_dependency.side_effect = lambda x: x
+        formatter.rosdep_validator.check_rosdeps_and_local_pkgs = MagicMock(
+            side_effect=lambda deps: []
+        )
+
+        example_pkgs = os.listdir(self.examples_dir)
+        bad_pkg_names = {"pkg_missing_launch_deps", "pkg_missing_test_depends"}
+        checked = 0
+        for example_pkg in example_pkgs:
+            pkg_dir = os.path.join(self.test_dir, example_pkg)
+            for pkg in os.listdir(pkg_dir):
+                if pkg not in bad_pkg_names:
+                    continue
+                xml_file = os.path.join(pkg_dir, pkg, "package.xml")
+                original_xml = os.path.join(
+                    self.examples_dir, example_pkg, pkg, "package.xml"
+                )
+                shutil.copy2(original_xml, xml_file)
+                with self.subTest(example_pkg=example_pkg, pkg=pkg):
+                    valid = formatter.check_and_format_files([xml_file])
+                    self.assertTrue(
+                        valid,
+                        f"XML file {xml_file} expected to validate when launch dep "
+                        f"check is skipped, but was reported invalid.",
+                    )
+                    self.assertTrue(
+                        self._compare_xml_files_and_print(xml_file, original_xml),
+                        f"XML file {xml_file} was modified even though "
+                        f"skip_launch_dep_check=True should leave it untouched.",
+                    )
+                    checked += 1
+        self.assertGreater(
+            checked, 0, "No bad-case example packages were exercised by this test."
+        )
+
     def test_xml_formatting(self):
         """
         Iterate over all example packages in the test directory,


### PR DESCRIPTION
## Summary
Three related dependency-handling improvements that give users finer control over what package.xml must declare:

- `ignore-deps` / _<!-- validator:ignore ... -->_ globally (CLI) or per-package (XML comment) suppress specific dependencies so they are not flagged as missing and not auto-filled. Intended for cases like rviz2 pulling in heavy transitive GUI deps that should not be installed on every target machine.
- `skip-launch-dep-check`: skip scanning launch/, components/, and test/ folders for implicit exec_depend / test_depend entries. Useful for packages where launch-file scanning produces false positives or is otherwise undesirable.
- `find_package(pkg QUIET)` is no longer enforced: a bare `QUIET` lookup (without `REQUIRED`) is semantically optional in CMake (the build continues if the package is missing), so the validator now treats it as optional and does not require it to appear in package.xml. find_package(<pkg> REQUIRED QUIET) remains enforced