### PR TITLE
Add strict typing across package, enable mypy in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,16 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.2
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-PyYAML, lxml-stubs]
+        # mypy reads its config from pyproject.toml; passing files here
+        # restricts it to the package source so it does not try to type-check
+        # the test suite (which is intentionally untyped).
+        files: ^package_xml_validation/.*\.py$
+
   # Spellcheck
   - repo: https://github.com/crate-ci/typos
     rev: v1.34.0
@@ -55,7 +65,7 @@ repos:
     hooks:
       - id: verify-rosdep-map
         name: Verify Rosdep Mappings
-        entry: python3 package_xml_validation/helpers/verify_rosdep_mapping.py
+        entry: python3 -m package_xml_validation.helpers.verify_rosdep_mapping
         language: system
         files: package_xml_validation/data/cmake_rosdep_map.yaml
         pass_filenames: false

--- a/package_xml_validation/helpers/cmake_parsers.py
+++ b/package_xml_validation/helpers/cmake_parsers.py
@@ -221,7 +221,7 @@ def retrieve_cmake_dependencies(
         r"^\s*find_package\s*\(\s*([^)]+)\)\s*$", re.IGNORECASE
     )
 
-    def add_deps(dep_list: list[str], is_test: bool):
+    def add_deps(dep_list: list[str], is_test: bool) -> None:
         if is_test:
             test_deps.extend(dep_list)
         else:

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -167,7 +167,7 @@ def _decomment_for_suffix(suffix: str, text: str) -> str:
     return text
 
 
-def scan_file(path: str, found: set[str], verbose: bool = False):
+def scan_file(path: str, found: set[str], verbose: bool = False) -> None:
     """Scan a single launch file for package references.
 
     Args:

--- a/package_xml_validation/helpers/logger.py
+++ b/package_xml_validation/helpers/logger.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
+from typing import Any
 
 
 class ColoredFormatter(logging.Formatter):
@@ -24,7 +27,7 @@ class ColoredFormatter(logging.Formatter):
         logging.CRITICAL: RED,
     }
 
-    def __init__(self, *args, use_color: bool = True, **kwargs):
+    def __init__(self, *args: Any, use_color: bool = True, **kwargs: Any) -> None:
         """Initialize the formatter with optional ANSI coloring.
 
         Args:
@@ -39,7 +42,7 @@ class ColoredFormatter(logging.Formatter):
         super().__init__(*args, **kwargs)
         self.use_color = use_color
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         """Format a log record and optionally colorize the output.
 
         Args:

--- a/package_xml_validation/helpers/logger.py
+++ b/package_xml_validation/helpers/logger.py
@@ -94,7 +94,9 @@ def get_logger(name: str = __name__, level: str | int = "normal") -> logging.Log
     logger.setLevel(logging.DEBUG)
 
     ch = logging.StreamHandler(sys.stdout)  # stdout is better for CI
-    ch.flush = sys.stdout.flush  # force flush after each log
+    # Force-flush after each log entry so CI output stays in order. mypy
+    # flags reassigning a method, but the runtime behavior is the point.
+    ch.flush = sys.stdout.flush  # type: ignore[method-assign]
 
     ch.setLevel(_resolve_level(level))
 

--- a/package_xml_validation/helpers/package_types.py
+++ b/package_xml_validation/helpers/package_types.py
@@ -2,17 +2,23 @@ from __future__ import annotations
 
 import os
 import re
+import sys
 from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from lxml.etree import _Element
 
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
     # Project-wide alias for an lxml element. Centralizing it here means the
     # rest of the codebase imports `XmlElement` instead of
     # `lxml.etree._Element`, so swapping the underlying type (e.g. wrapping
     # it in a domain class) only requires editing this line.
-    XmlElement = _Element
+    XmlElement: TypeAlias = _Element
 
 
 class PackageType(Enum):

--- a/package_xml_validation/helpers/package_types.py
+++ b/package_xml_validation/helpers/package_types.py
@@ -1,6 +1,18 @@
+from __future__ import annotations
+
 import os
 import re
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lxml.etree import _Element
+
+    # Project-wide alias for an lxml element. Centralizing it here means the
+    # rest of the codebase imports `XmlElement` instead of
+    # `lxml.etree._Element`, so swapping the underlying type (e.g. wrapping
+    # it in a domain class) only requires editing this line.
+    XmlElement = _Element
 
 
 class PackageType(Enum):

--- a/package_xml_validation/helpers/pkg_xml_formatter.py
+++ b/package_xml_validation/helpers/pkg_xml_formatter.py
@@ -131,14 +131,19 @@ class PackageXmlFormatter:
         """
 
         dependency_order = [elm[0] for elm in ELEMENTS]
-        dependencies_with_comments = {dep: [] for dep in dependency_order}
-        current_order = []
+        dependencies_with_comments: dict[
+            str, list[tuple[XmlElement, list[XmlElement]]]
+        ] = {dep: [] for dep in dependency_order}
+        current_order: list[str] = []
 
         # Collect dependencies and track their order
-        current_comments = []
+        current_comments: list[XmlElement] = []
         for elem in root:
-            if elem.tag is ET.Comment:
-                current_comments.append(elem)
+            # lxml-stubs types ``elem.tag`` as ``str``; at runtime comment
+            # nodes have ``tag is ET.Comment`` (a callable), so the identity
+            # check is intentional.
+            if elem.tag is ET.Comment:  # type: ignore[comparison-overlap]
+                current_comments.append(elem)  # type: ignore[unreachable]
             if isinstance(elem.tag, str) and elem.tag in dependency_order:
                 dependencies_with_comments[elem.tag].append((elem, current_comments))
                 current_comments = []
@@ -160,7 +165,7 @@ class PackageXmlFormatter:
         # Check alphabetical order within each group
         if current_order == correct_order:
             for dep_type, elem_with_commtents in dependencies_with_comments.items():
-                names = [e[0].text for e in elem_with_commtents]
+                names = [e[0].text or "" for e in elem_with_commtents]
                 if names != sorted(names):
                     self.logger.debug(
                         f"Dependency order in {xml_file} is incorrect: {dep_type} elements are not sorted."
@@ -181,10 +186,10 @@ class PackageXmlFormatter:
         indentation = self._resolve_indentation(root)
         # Remove old dependency elements from root
         for dep_type in dependency_order:
-            for elem in dependencies_with_comments[dep_type]:
-                for comment in elem[1]:
+            for dep_elem, dep_comments in dependencies_with_comments[dep_type]:
+                for comment in dep_comments:
                     root.remove(comment)
-                root.remove(elem[0])
+                root.remove(dep_elem)
         # filter out empty lists from dependency order
         dependency_order = [
             dep for dep in dependency_order if dependencies_with_comments[dep]
@@ -192,7 +197,7 @@ class PackageXmlFormatter:
         insert_index = 0
         for index, dep_type in enumerate(dependency_order):
             sorted_elems = sorted(
-                dependencies_with_comments[dep_type], key=lambda x: x[0].text
+                dependencies_with_comments[dep_type], key=lambda x: x[0].text or ""
             )
             for i, elem_with_comment in enumerate(sorted_elems):
                 if (
@@ -240,11 +245,11 @@ class PackageXmlFormatter:
             """
             return ET.tostring(elem, with_tail=False)
 
-        seen = set()
-        duplicates = []
+        seen: set[bytes] = set()
+        duplicates: list[XmlElement] = []
         for elem in root:
-            if elem.tag is ET.Comment:
-                continue
+            if elem.tag is ET.Comment:  # type: ignore[comparison-overlap]
+                continue  # type: ignore[unreachable]
             combined = element_signature(elem)
             if combined in seen:
                 duplicates.append(elem)
@@ -391,14 +396,14 @@ class PackageXmlFormatter:
                 return len(element_order)
 
         # Extract elements and their preceding comments
-        elements_with_comments = []
-        current_comments = []
+        elements_with_comments: list[tuple[XmlElement, list[XmlElement]]] = []
+        current_comments: list[XmlElement] = []
 
         last_tail = ""
         indentation = self._resolve_indentation(root)
         for elem in root:
-            if elem.tag is ET.Comment:
-                self.logger.error(f"Found comment: {elem.text}")
+            if elem.tag is ET.Comment:  # type: ignore[comparison-overlap]
+                self.logger.error(f"Found comment: {elem.text}")  # type: ignore[unreachable]
                 if last_tail and last_tail[-1] == NEW_LINE:
                     # inline comment -> append to previous element
                     elements_with_comments[-1][0].tail = elem.tail
@@ -740,7 +745,8 @@ class PackageXmlFormatter:
         if dep_type not in dep_types:
             raise ValueError(f"Invalid dependency type: {dep_type}")
         indentation = self._resolve_indentation(root)
-        insert_position, first_of_group = 0, 0
+        insert_position: int = 0
+        first_of_group: int | None = 0
         for dep in dependencies:
             new_elem = ET.Element(dep_type)
             new_elem.text = dep
@@ -748,13 +754,13 @@ class PackageXmlFormatter:
             # add element to root at correct position -> correct dep group and alphabetical order
             # case 1: dependency group is empty
             if not root.findall(dep_type):
-                previous_element = elements[elements.index(dep_type) - 1]
-                while not root.findall(previous_element):
-                    previous_element = elements[elements.index(previous_element) - 1]
-                # find last element with previous_element tag
+                previous_tag = elements[elements.index(dep_type) - 1]
+                while not root.findall(previous_tag):
+                    previous_tag = elements[elements.index(previous_tag) - 1]
+                # find last element with previous_tag
                 last_element_count = 0
                 for count, elm in enumerate(root):
-                    if isinstance(elm.tag, str) and elm.tag == previous_element:
+                    if isinstance(elm.tag, str) and elm.tag == previous_tag:
                         last_element_count = count
                 insert_position = last_element_count + 1
                 first_of_group = insert_position
@@ -768,7 +774,7 @@ class PackageXmlFormatter:
                         if first_of_group is None:
                             first_of_group = i
                             insert_position = i
-                        if elm.text < new_elem.text:
+                        if (elm.text or "") < (new_elem.text or ""):
                             insert_position = i + 1
             root.insert(insert_position, new_elem)
             # adapt empty lines -> in case element prior ends with empty line move it to the new element
@@ -777,10 +783,10 @@ class PackageXmlFormatter:
                 and first_of_group is not None
                 and insert_position > first_of_group
             ):
-                previous_element = root[insert_position - 1]
-                if previous_element.tail and previous_element.tail.count(NEW_LINE) > 1:
-                    new_elem.tail = previous_element.tail
-                    previous_element.tail = NEW_LINE + indentation
+                prev_elem = root[insert_position - 1]
+                if prev_elem.tail and prev_elem.tail.count(NEW_LINE) > 1:
+                    new_elem.tail = prev_elem.tail
+                    prev_elem.tail = NEW_LINE + indentation
             if insert_position < len(root) - 1:
                 # if next tag is different than the new element, add empty line
                 next_element = root[insert_position + 1]

--- a/package_xml_validation/helpers/pkg_xml_formatter.py
+++ b/package_xml_validation/helpers/pkg_xml_formatter.py
@@ -1,11 +1,19 @@
-import lxml.etree as ET
-from copy import deepcopy
+from __future__ import annotations
 
+import logging
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+from collections.abc import Iterable
+
+import lxml.etree as ET
 
 try:
     from .logger import get_logger
 except ImportError:
-    from helpers.logger import get_logger
+    from helpers.logger import get_logger  # type: ignore[no-redef]
+
+if TYPE_CHECKING:
+    from .package_types import XmlElement
 
 # tuple of (element_name, min_occurrences, max_occurrences)
 # min_occurrences is 1 if the element is required, 0 if it can be missing
@@ -49,11 +57,11 @@ NEW_LINE = "\n"
 class PackageXmlFormatter:
     def __init__(
         self,
-        check_only=False,
-        verbose=False,
-        check_with_xmllint=False,
-        logger=None,
-    ):
+        check_only: bool = False,
+        verbose: bool = False,
+        check_with_xmllint: bool = False,
+        logger: logging.Logger | None = None,
+    ) -> None:
         """Initialize formatter configuration and logger.
 
         Args:
@@ -75,7 +83,7 @@ class PackageXmlFormatter:
         )
         self.encountered_unresolvable_error = False
 
-    def _resolve_indentation(self, root, default="  ") -> str:
+    def _resolve_indentation(self, root: XmlElement, default: str = "  ") -> str:
         """Infer indentation from the first child tail, or return a default.
 
         Args:
@@ -95,7 +103,7 @@ class PackageXmlFormatter:
             return tail[tail.rfind(NEW_LINE) + 1 :]
         return tail
 
-    def prettyprint(self, element, **kwargs):
+    def prettyprint(self, element: XmlElement, **kwargs: Any) -> None:
         """Print a pretty-printed XML element to stdout.
 
         Args:
@@ -109,7 +117,7 @@ class PackageXmlFormatter:
         xml = ET.tostring(element, pretty_print=True, **kwargs)
         print(xml.decode(), end="")
 
-    def check_dependency_order(self, root, xml_file):
+    def check_dependency_order(self, root: XmlElement, xml_file: str) -> bool:
         """Check and optionally correct dependency ordering.
 
         Args:
@@ -205,7 +213,7 @@ class PackageXmlFormatter:
         self.logger.info(f"Corrected dependency order in {xml_file}.")
         return False
 
-    def check_for_duplicates(self, root, xml_file):
+    def check_for_duplicates(self, root: XmlElement, xml_file: str) -> bool:
         """
         Check for duplicate elements in the XML file.
         -> meaning tag, text, attributes, and children are the same
@@ -220,7 +228,7 @@ class PackageXmlFormatter:
 
         """
 
-        def element_signature(elem) -> bytes:
+        def element_signature(elem: XmlElement) -> bytes:
             """Serialize an element to bytes for duplicate detection.
 
             Args:
@@ -261,7 +269,7 @@ class PackageXmlFormatter:
             root.remove(elem)
         return False
 
-    def check_element_occurrences(self, root, xml_file):
+    def check_element_occurrences(self, root: XmlElement, xml_file: str) -> bool:
         """
         Check the min/max occurrences of elements in the XML file.
         If self.check_only is True, only check for errors without correcting.
@@ -327,7 +335,7 @@ class PackageXmlFormatter:
                 self.logger.warning(f"Please add the missing element: <{elem}>")
         return False
 
-    def check_element_order(self, root, xml_file):
+    def check_element_order(self, root: XmlElement, xml_file: str) -> bool:
         """
         Check if the elements in the XML file are in the expected order,
         ensuring comments remain in front of their respective elements.
@@ -366,7 +374,7 @@ class PackageXmlFormatter:
             return True
 
         # Helper function to determine the sort key
-        def sort_key(elem):
+        def sort_key(elem: XmlElement) -> int:
             """Return sort key based on expected element ordering.
 
             Args:
@@ -422,7 +430,7 @@ class PackageXmlFormatter:
 
         return False
 
-    def check_for_empty_lines(self, root, xml_file):
+    def check_for_empty_lines(self, root: XmlElement, xml_file: str) -> bool:
         """
         Check for empty lines in the XML file.
         Make sure there are no more than one empty line between elements.
@@ -437,7 +445,7 @@ class PackageXmlFormatter:
 
         """
 
-        def remove_inner_newlines(s):
+        def remove_inner_newlines(s: str) -> str:
             """Collapse multiple inner newlines to a single blank line.
 
             Args:
@@ -491,7 +499,9 @@ class PackageXmlFormatter:
                 elm.tail = NEW_LINE + indentation
         return False
 
-    def check_indentation(self, root, level=1, indentation="  "):
+    def check_indentation(
+        self, root: XmlElement, level: int = 1, indentation: str = "  "
+    ) -> bool:
         """
         Check if the indentation of the XML file is correct.
         recursively checks the indentation of each element.
@@ -508,7 +518,7 @@ class PackageXmlFormatter:
         """
         is_correct = True
 
-        def check_indentation_string(string, expected_indent) -> bool:
+        def check_indentation_string(string: str | None, expected_indent: str) -> bool:
             """Validate indentation string against expected indentation.
 
             Args:
@@ -524,7 +534,7 @@ class PackageXmlFormatter:
             parsed_indentation = string.replace(NEW_LINE, "")
             return parsed_indentation == expected_indent and NEW_LINE in string
 
-        def fix_indentation(string, expected_indent) -> str:
+        def fix_indentation(string: str | None, expected_indent: str) -> str:
             """Fix the indentation of the string to match the expected_indent.
 
             Args:
@@ -540,7 +550,9 @@ class PackageXmlFormatter:
             )
             return indent + expected_indent
 
-        def check_and_correct(string, expected_indent, name) -> tuple[str, bool]:
+        def check_and_correct(
+            string: str | None, expected_indent: str, name: str
+        ) -> tuple[str | None, bool]:
             """Check and optionally correct indentation.
 
             Args:
@@ -598,7 +610,7 @@ class PackageXmlFormatter:
             self.logger.warning("Auto-corrected indentation in package.xml.")
         return is_correct
 
-    def check_for_non_existing_tags(self, root, xml_file):
+    def check_for_non_existing_tags(self, root: XmlElement, xml_file: str) -> bool:
         """Check for tags that are not part of the allowed package.xml schema.
 
         Args:
@@ -621,7 +633,7 @@ class PackageXmlFormatter:
             return False
         return True
 
-    def retrieve_all_dependencies(self, root):
+    def retrieve_all_dependencies(self, root: XmlElement) -> list[str]:
         """Retrieve all dependency tag values from the XML tree.
 
         Args:
@@ -637,7 +649,7 @@ class PackageXmlFormatter:
                 dependencies.append(elem.text.strip())
         return dependencies
 
-    def retrieve_build_dependencies(self, root):
+    def retrieve_build_dependencies(self, root: XmlElement) -> list[str]:
         """Retrieve build-related dependencies from the XML tree.
 
         Args:
@@ -660,7 +672,7 @@ class PackageXmlFormatter:
                 build_dependencies.append(elem.text.strip())
         return build_dependencies
 
-    def retrieve_test_dependencies(self, root):
+    def retrieve_test_dependencies(self, root: XmlElement) -> list[str]:
         """Retrieve test dependencies from the XML tree.
 
         Args:
@@ -677,7 +689,7 @@ class PackageXmlFormatter:
                 test_dependencies.append(elem.text.strip())
         return test_dependencies
 
-    def retrieve_exec_dependencies(self, root):
+    def retrieve_exec_dependencies(self, root: XmlElement) -> list[str]:
         """Retrieve execution dependencies from the XML tree.
 
         Args:
@@ -694,7 +706,7 @@ class PackageXmlFormatter:
                 exec_dependencies.append(elem.text.strip())
         return exec_dependencies
 
-    def get_package_name(self, root) -> str | None:
+    def get_package_name(self, root: XmlElement) -> str | None:
         """Retrieve the package name from the XML tree.
 
         Args:
@@ -709,7 +721,9 @@ class PackageXmlFormatter:
             return name_elem.text.strip()
         return None
 
-    def add_dependencies(self, root, dependencies, dep_type):
+    def add_dependencies(
+        self, root: XmlElement, dependencies: Iterable[str], dep_type: str
+    ) -> None:
         """Add dependency elements to the XML tree in sorted order.
 
         Args:
@@ -773,7 +787,7 @@ class PackageXmlFormatter:
                 if next_element.tag != new_elem.tag:
                     new_elem.tail = "\n\n" + indentation
 
-    def add_build_type_export(self, root, build_type: str):
+    def add_build_type_export(self, root: XmlElement, build_type: str) -> None:
         """
         Add the build type export to the XML file.
         If the build type export already exists, it will be updated.
@@ -807,7 +821,7 @@ class PackageXmlFormatter:
         build_type_elem.text = build_type
         export.text = NEW_LINE + 2 * indentation
 
-    def add_buildtool_depends(self, root, buildtool: list[str]):
+    def add_buildtool_depends(self, root: XmlElement, buildtool: list[str]) -> None:
         """
         Add the buildtool_depend to the XML file.
         If the buildtool_depend already exists, it will be updated.
@@ -844,7 +858,7 @@ class PackageXmlFormatter:
             root.insert(insert_position, new_elem)
             insert_position += 1
 
-    def add_member_of_group(self, root, group_name: str):
+    def add_member_of_group(self, root: XmlElement, group_name: str) -> None:
         """Add a member_of_group element to the XML tree.
 
         Args:

--- a/package_xml_validation/helpers/rosdep_validator.py
+++ b/package_xml_validation/helpers/rosdep_validator.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import re
 import yaml
 import difflib
 from importlib import resources
+from typing import Any
+from collections.abc import Iterable
+from re import Pattern
 
 from . import rosdep_wrapper
 
@@ -17,7 +22,7 @@ try:
     from .workspace import get_pkgs_in_wrs
 except ImportError:
 
-    def get_pkgs_in_wrs(path):
+    def get_pkgs_in_wrs(path: Any) -> list[str]:
         """Fallback workspace package discovery when helpers cannot be imported.
 
         Args:
@@ -35,7 +40,7 @@ class RosdepValidator:
     Class to validate ROS dependencies using rosdep.
     """
 
-    def __init__(self, pkg_path=None):
+    def __init__(self, pkg_path: str | None = None) -> None:
         """Initialize rosdep lookup and optional workspace package list.
 
         Args:
@@ -63,7 +68,7 @@ class RosdepValidator:
 
         self._cached_data_source_cls = rosdep_wrapper.get_cached_data_source_cls()
 
-        self.local_pkgs = []
+        self.local_pkgs: list[str] = []
         if pkg_path:
             self.local_pkgs = get_pkgs_in_wrs(pkg_path)
 
@@ -180,7 +185,7 @@ class RosdepValidator:
         unique_keys = list(set(found_keys))
 
         # --- IMPROVED SORTING LOGIC ---
-        def sort_key(candidate):
+        def sort_key(candidate: str) -> tuple[int, float]:
             cand_lower = candidate.lower()
             dep_lower = dependency.lower()
 
@@ -206,7 +211,9 @@ class RosdepValidator:
 
         return sorted(unique_keys, key=sort_key)[:5]
 
-    def _search_view_data(self, view, compiled_regexes) -> list[str]:
+    def _search_view_data(
+        self, view: Any, compiled_regexes: list[Pattern[str]]
+    ) -> list[str]:
         """Search a rosdep view for matching keys or payload values.
 
         Args:
@@ -228,7 +235,9 @@ class RosdepValidator:
                     matches.append(key)
         return matches
 
-    def _check_payload_match(self, os_payload, compiled_regexes) -> bool:
+    def _check_payload_match(
+        self, os_payload: Any, compiled_regexes: list[Pattern[str]]
+    ) -> bool:
         """Check whether a payload contains any regex matches.
 
         Args:
@@ -257,7 +266,7 @@ class RosdepValidator:
                     return True
         return False
 
-    def check_rosdeps(self, dependencies) -> list[str]:
+    def check_rosdeps(self, dependencies: Iterable[str]) -> list[str]:
         """Return a list of rosdep keys that cannot be resolved.
 
         Args:
@@ -273,7 +282,7 @@ class RosdepValidator:
                 unresolvable.append(dep)
         return unresolvable
 
-    def check_rosdeps_and_local_pkgs(self, dependencies) -> list[str]:
+    def check_rosdeps_and_local_pkgs(self, dependencies: Iterable[str]) -> list[str]:
         """Return rosdep keys unresolved and not satisfied by local packages.
 
         Args:

--- a/package_xml_validation/helpers/rosdep_validator.py
+++ b/package_xml_validation/helpers/rosdep_validator.py
@@ -4,9 +4,9 @@ import re
 import yaml
 import difflib
 from importlib import resources
+from pathlib import Path
 from typing import Any
 from collections.abc import Iterable
-from re import Pattern
 
 from . import rosdep_wrapper
 
@@ -22,7 +22,7 @@ try:
     from .workspace import get_pkgs_in_wrs
 except ImportError:
 
-    def get_pkgs_in_wrs(path: Any) -> list[str]:
+    def get_pkgs_in_wrs(path: str | Path) -> list[str]:
         """Fallback workspace package discovery when helpers cannot be imported.
 
         Args:
@@ -154,7 +154,9 @@ class RosdepValidator:
             A list of up to five candidate rosdep keys, sorted by relevance.
 
         """
-        regexes = []
+        # ``regex`` and ``re`` produce distinct (but duck-compatible) Pattern
+        # types. Annotated as Any to let either populate the list.
+        regexes: list[Any] = []
         if HAS_REGEX_MODULE:
             # Fuzzy matching: allow 2 errors for long strings, 1 for short
             error_tolerance = 2 if len(dependency) >= 7 else 1
@@ -164,7 +166,7 @@ class RosdepValidator:
             # Fallback: standard regex
             regexes.append(re.compile(re.escape(dependency), re.IGNORECASE))
 
-        found_keys = []
+        found_keys: list[str] = []
 
         # Iterate over cached views
         for view_name in self.sources_loader.get_loadable_views():
@@ -211,9 +213,7 @@ class RosdepValidator:
 
         return sorted(unique_keys, key=sort_key)[:5]
 
-    def _search_view_data(
-        self, view: Any, compiled_regexes: list[Pattern[str]]
-    ) -> list[str]:
+    def _search_view_data(self, view: Any, compiled_regexes: list[Any]) -> list[str]:
         """Search a rosdep view for matching keys or payload values.
 
         Args:
@@ -236,7 +236,7 @@ class RosdepValidator:
         return matches
 
     def _check_payload_match(
-        self, os_payload: Any, compiled_regexes: list[Pattern[str]]
+        self, os_payload: Any, compiled_regexes: list[Any]
     ) -> bool:
         """Check whether a payload contains any regex matches.
 

--- a/package_xml_validation/helpers/rosdep_validator.py
+++ b/package_xml_validation/helpers/rosdep_validator.py
@@ -3,13 +3,7 @@ import yaml
 import difflib
 from importlib import resources
 
-# ROS imports
-import rosdep2
-from rosdep2.sources_list import (
-    SourcesListLoader,
-    CachedDataSource,
-    get_sources_cache_dir,
-)
+from . import rosdep_wrapper
 
 # Try importing regex for fuzzy matching
 try:
@@ -51,8 +45,8 @@ class RosdepValidator:
             None.
 
         """
-        self.rosdep_installer_context = rosdep2.create_default_installer_context()
-        self.rosdep = rosdep2.RosdepLookup.create_from_rospkg()
+        self.rosdep_installer_context = rosdep_wrapper.create_installer_context()
+        self.rosdep = rosdep_wrapper.create_lookup_from_rospkg()
 
         (
             self.rosdep_os_name,
@@ -60,12 +54,14 @@ class RosdepValidator:
         ) = self.rosdep_installer_context.get_os_name_and_version()
 
         self.rosdep_view = self.rosdep.get_rosdep_view(
-            rosdep2.rospkg_loader.DEFAULT_VIEW_KEY
+            rosdep_wrapper.get_default_view_key()
         )
 
-        self.sources_loader = SourcesListLoader.create_default(
-            sources_cache_dir=get_sources_cache_dir(), verbose=False
+        self.sources_loader = rosdep_wrapper.create_default_sources_loader(
+            verbose=False
         )
+
+        self._cached_data_source_cls = rosdep_wrapper.get_cached_data_source_cls()
 
         self.local_pkgs = []
         if pkg_path:
@@ -119,7 +115,7 @@ class RosdepValidator:
                 ),
             )
             return installer is not None
-        except (rosdep2.ResolutionError, KeyError):
+        except (rosdep_wrapper.ResolutionError, KeyError):
             return False
         except Exception:
             return False
@@ -173,7 +169,7 @@ class RosdepValidator:
                 continue
 
             # Skip remote sources
-            if not isinstance(view, CachedDataSource) or not hasattr(
+            if not isinstance(view, self._cached_data_source_cls) or not hasattr(
                 view, "rosdep_data"
             ):
                 continue

--- a/package_xml_validation/helpers/rosdep_wrapper.py
+++ b/package_xml_validation/helpers/rosdep_wrapper.py
@@ -1,0 +1,79 @@
+"""Typed boundary around the untyped ``rosdep2`` package.
+
+All ``rosdep2`` imports live here. Other modules in this project should import
+from this wrapper instead of touching ``rosdep2`` directly. That way the
+``# type: ignore`` comments stay in one place, and if ``rosdep2`` ever ships
+type stubs (or gets replaced) only this file changes.
+
+Every wrapper function imports ``rosdep2`` lazily so that:
+* tests which install a fake ``rosdep2`` into ``sys.modules`` do not need to
+  also reload this wrapper, and
+* tests which patch ``rosdep2.create_default_installer_context`` (and
+  similar) keep working unchanged - the patch is resolved through
+  ``sys.modules`` at call time rather than against a name captured at import.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    # Runtime-untyped objects exposed as ``Any`` aliases so call sites have
+    # meaningful names at type-check time.
+    InstallerContext = Any
+    RosdepView = Any
+    RosdepDefinition = Any
+    SourcesLoader = Any
+    CachedDataSourceT = Any
+    ResolutionError = Exception
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose select rosdep2 attributes (e.g. ``ResolutionError``)."""
+    if name == "ResolutionError":
+        import rosdep2  # type: ignore[import-untyped]
+
+        return rosdep2.ResolutionError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def get_default_view_key() -> str:
+    """Return the rospkg loader's default view key."""
+    from rosdep2.rospkg_loader import DEFAULT_VIEW_KEY  # type: ignore[import-untyped]
+
+    return DEFAULT_VIEW_KEY
+
+
+def get_cached_data_source_cls() -> type:
+    """Return the ``CachedDataSource`` class for use in ``isinstance`` checks."""
+    from rosdep2.sources_list import CachedDataSource  # type: ignore[import-untyped]
+
+    return CachedDataSource
+
+
+def create_installer_context() -> Any:
+    """Return a default rosdep installer context."""
+    import rosdep2  # type: ignore[import-untyped]
+
+    return rosdep2.create_default_installer_context()
+
+
+def create_lookup_from_rospkg() -> Any:
+    """Return a ``RosdepLookup`` populated from rospkg."""
+    import rosdep2  # type: ignore[import-untyped]
+
+    return rosdep2.RosdepLookup.create_from_rospkg()
+
+
+def create_default_sources_loader(*, verbose: bool = False) -> Any:
+    """Return a ``SourcesListLoader`` rooted at the default sources cache."""
+    from rosdep2.sources_list import (  # type: ignore[import-untyped]
+        SourcesListLoader,
+        get_sources_cache_dir,
+    )
+
+    return SourcesListLoader.create_default(
+        sources_cache_dir=get_sources_cache_dir(),
+        verbose=verbose,
+    )

--- a/package_xml_validation/helpers/rosdep_wrapper.py
+++ b/package_xml_validation/helpers/rosdep_wrapper.py
@@ -1,16 +1,19 @@
 """Typed boundary around the untyped ``rosdep2`` package.
 
-All ``rosdep2`` imports live here. Other modules in this project should import
-from this wrapper instead of touching ``rosdep2`` directly. That way the
-``# type: ignore`` comments stay in one place, and if ``rosdep2`` ever ships
-type stubs (or gets replaced) only this file changes.
+All ``rosdep2`` imports live here. Other modules in this project should
+import from this wrapper instead of touching ``rosdep2`` directly. The
+``rosdep2.*`` modules are silenced for mypy via a per-module override in
+``pyproject.toml``; this is the single place that exception applies, so
+if ``rosdep2`` ever ships type stubs (or gets replaced) only this file
+changes.
 
 Every wrapper function imports ``rosdep2`` lazily so that:
-* tests which install a fake ``rosdep2`` into ``sys.modules`` do not need to
-  also reload this wrapper, and
+* tests which install a fake ``rosdep2`` into ``sys.modules`` do not need
+  to also reload this wrapper, and
 * tests which patch ``rosdep2.create_default_installer_context`` (and
   similar) keep working unchanged - the patch is resolved through
-  ``sys.modules`` at call time rather than against a name captured at import.
+  ``sys.modules`` at call time rather than against a name captured at
+  import.
 """
 
 from __future__ import annotations
@@ -32,7 +35,7 @@ if TYPE_CHECKING:
 def __getattr__(name: str) -> Any:
     """Lazily expose select rosdep2 attributes (e.g. ``ResolutionError``)."""
     if name == "ResolutionError":
-        import rosdep2  # type: ignore[import-untyped]
+        import rosdep2
 
         return rosdep2.ResolutionError
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
@@ -40,38 +43,36 @@ def __getattr__(name: str) -> Any:
 
 def get_default_view_key() -> str:
     """Return the rospkg loader's default view key."""
-    from rosdep2.rospkg_loader import DEFAULT_VIEW_KEY  # type: ignore[import-untyped]
+    from rosdep2.rospkg_loader import DEFAULT_VIEW_KEY
 
-    return DEFAULT_VIEW_KEY
+    return str(DEFAULT_VIEW_KEY)
 
 
 def get_cached_data_source_cls() -> type:
     """Return the ``CachedDataSource`` class for use in ``isinstance`` checks."""
-    from rosdep2.sources_list import CachedDataSource  # type: ignore[import-untyped]
+    from rosdep2.sources_list import CachedDataSource
 
-    return CachedDataSource
+    cls: type = CachedDataSource
+    return cls
 
 
 def create_installer_context() -> Any:
     """Return a default rosdep installer context."""
-    import rosdep2  # type: ignore[import-untyped]
+    import rosdep2
 
     return rosdep2.create_default_installer_context()
 
 
 def create_lookup_from_rospkg() -> Any:
     """Return a ``RosdepLookup`` populated from rospkg."""
-    import rosdep2  # type: ignore[import-untyped]
+    import rosdep2
 
     return rosdep2.RosdepLookup.create_from_rospkg()
 
 
 def create_default_sources_loader(*, verbose: bool = False) -> Any:
     """Return a ``SourcesListLoader`` rooted at the default sources cache."""
-    from rosdep2.sources_list import (  # type: ignore[import-untyped]
-        SourcesListLoader,
-        get_sources_cache_dir,
-    )
+    from rosdep2.sources_list import SourcesListLoader, get_sources_cache_dir
 
     return SourcesListLoader.create_default(
         sources_cache_dir=get_sources_cache_dir(),

--- a/package_xml_validation/helpers/validation_steps.py
+++ b/package_xml_validation/helpers/validation_steps.py
@@ -353,7 +353,7 @@ class BuildTypeExportStep(ValidationStep):
         pkg_type, _ = get_package_type(xml_file)
         export = root.find("export")
         export_exists = export is not None
-        build_type = export.find("build_type") if export_exists else None
+        build_type = export.find("build_type") if export is not None else None
         build_type_correct = (
             (
                 pkg_type == PackageType.CMAKE_PKG

--- a/package_xml_validation/helpers/validation_steps.py
+++ b/package_xml_validation/helpers/validation_steps.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from .cmake_parsers import read_deps_from_cmake_file
 from .find_launch_dependencies import scan_files
 from .package_types import PackageType, get_package_type
+
+if TYPE_CHECKING:
+    from .package_types import XmlElement
+    from .pkg_xml_formatter import PackageXmlFormatter
+    from .rosdep_validator import RosdepValidator
 
 
 @dataclass(frozen=True)
@@ -20,7 +27,7 @@ class ValidationConfig:
 
 @dataclass
 class ValidationResult:
-    root: object
+    root: XmlElement
     warnings: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     critical_errors: list[str] = field(default_factory=list)
@@ -31,7 +38,7 @@ class ValidationResult:
 class ValidationStep:
     name = "Validation step"
 
-    def __init__(self, config: ValidationConfig):
+    def __init__(self, config: ValidationConfig) -> None:
         """Initialize a validation step with configuration.
 
         Args:
@@ -43,7 +50,7 @@ class ValidationStep:
         """
         self.config = config
 
-    def perform_check(self, root, xml_file: str) -> ValidationResult:
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
         """Perform the validation step for a package.xml file.
 
         Args:
@@ -60,7 +67,9 @@ class ValidationStep:
 class FormatterValidationStep(ValidationStep):
     name = "Formatter validation"
 
-    def __init__(self, config: ValidationConfig, formatter):
+    def __init__(
+        self, config: ValidationConfig, formatter: PackageXmlFormatter
+    ) -> None:
         """Initialize formatting validation step.
 
         Args:
@@ -74,7 +83,7 @@ class FormatterValidationStep(ValidationStep):
         super().__init__(config)
         self.formatter = formatter
 
-    def perform_check(self, root, xml_file: str) -> ValidationResult:
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
         """Run formatting-related checks on a package.xml file.
 
         Args:
@@ -148,7 +157,9 @@ class FormatterValidationStep(ValidationStep):
 class BuildToolDependStep(ValidationStep):
     name = "Build tool dependency"
 
-    def __init__(self, config: ValidationConfig, formatter):
+    def __init__(
+        self, config: ValidationConfig, formatter: PackageXmlFormatter
+    ) -> None:
         """Initialize buildtool dependency validation step.
 
         Args:
@@ -162,7 +173,7 @@ class BuildToolDependStep(ValidationStep):
         super().__init__(config)
         self.formatter = formatter
 
-    def perform_check(self, root, xml_file: str) -> ValidationResult:
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
         """Validate and optionally fix buildtool dependency tags.
 
         Args:
@@ -239,7 +250,9 @@ class BuildToolDependStep(ValidationStep):
 class MemberOfGroupStep(ValidationStep):
     name = "Member of group"
 
-    def __init__(self, config: ValidationConfig, formatter):
+    def __init__(
+        self, config: ValidationConfig, formatter: PackageXmlFormatter
+    ) -> None:
         """Initialize member_of_group validation step.
 
         Args:
@@ -253,7 +266,7 @@ class MemberOfGroupStep(ValidationStep):
         super().__init__(config)
         self.formatter = formatter
 
-    def perform_check(self, root, xml_file: str) -> ValidationResult:
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
         """Validate and optionally fix member_of_group tag for msg packages.
 
         Args:
@@ -306,7 +319,9 @@ class MemberOfGroupStep(ValidationStep):
 class BuildTypeExportStep(ValidationStep):
     name = "Build type export"
 
-    def __init__(self, config: ValidationConfig, formatter):
+    def __init__(
+        self, config: ValidationConfig, formatter: PackageXmlFormatter
+    ) -> None:
         """Initialize build type export validation step.
 
         Args:
@@ -320,7 +335,7 @@ class BuildTypeExportStep(ValidationStep):
         super().__init__(config)
         self.formatter = formatter
 
-    def perform_check(self, root, xml_file: str) -> ValidationResult:
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
         """Validate and optionally fix <export><build_type> for packages.
 
         Args:
@@ -391,7 +406,12 @@ class BuildTypeExportStep(ValidationStep):
 class RosdepCheckStep(ValidationStep):
     name = "ROS dependency check"
 
-    def __init__(self, config: ValidationConfig, formatter, rosdep_validator):
+    def __init__(
+        self,
+        config: ValidationConfig,
+        formatter: PackageXmlFormatter,
+        rosdep_validator: RosdepValidator,
+    ) -> None:
         """Initialize ROS dependency validation step.
 
         Args:
@@ -407,7 +427,7 @@ class RosdepCheckStep(ValidationStep):
         self.formatter = formatter
         self.rosdep_validator = rosdep_validator
 
-    def perform_check(self, root, xml_file: str) -> ValidationResult:
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
         """Validate rosdep keys in package.xml dependencies.
 
         Args:
@@ -443,7 +463,12 @@ class RosdepCheckStep(ValidationStep):
 class CMakeComparisonStep(ValidationStep):
     name = "CMake dependency comparison"
 
-    def __init__(self, config: ValidationConfig, formatter, rosdep_validator):
+    def __init__(
+        self,
+        config: ValidationConfig,
+        formatter: PackageXmlFormatter,
+        rosdep_validator: RosdepValidator,
+    ) -> None:
         """Initialize CMake comparison validation step.
 
         Args:
@@ -459,7 +484,7 @@ class CMakeComparisonStep(ValidationStep):
         self.formatter = formatter
         self.rosdep_validator = rosdep_validator
 
-    def perform_check(self, root, xml_file: str) -> ValidationResult:
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
         """Compare CMakeLists.txt dependencies to package.xml entries.
 
         Args:
@@ -600,12 +625,12 @@ class LaunchDependencyStep(ValidationStep):
     def __init__(
         self,
         config: ValidationConfig,
-        formatter,
-        rosdep_validator,
-        package_name: str,
+        formatter: PackageXmlFormatter,
+        rosdep_validator: RosdepValidator | None,
+        package_name: str | None,
         exec_deps: list[str],
         test_deps: list[str],
-    ):
+    ) -> None:
         """Initialize launch dependency validation step.
 
         Args:
@@ -627,7 +652,7 @@ class LaunchDependencyStep(ValidationStep):
         self.exec_deps = exec_deps
         self.test_deps = test_deps
 
-    def perform_check(self, root, xml_file: str) -> ValidationResult:
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
         """Validate launch/test file dependencies against package.xml.
 
         Args:
@@ -699,7 +724,7 @@ class LaunchDependencyStep(ValidationStep):
                 result.valid = False
                 return
 
-            if self.config.check_rosdeps:
+            if self.config.check_rosdeps and self.rosdep_validator is not None:
                 invalid_deps = self.rosdep_validator.check_rosdeps_and_local_pkgs(
                     missing_deps
                 )

--- a/package_xml_validation/helpers/verify_rosdep_mapping.py
+++ b/package_xml_validation/helpers/verify_rosdep_mapping.py
@@ -3,16 +3,16 @@ import sys
 import yaml
 import pathlib
 
-# Try importing rosdep2
 try:
-    import rosdep2
-    from rosdep2.rospkg_loader import DEFAULT_VIEW_KEY
+    import rosdep2  # noqa: F401  # presence check; real calls go via rosdep_wrapper
 except ImportError:
     print(
         "Error: 'rosdep2' module not found. Please install python3-rosdep.",
         file=sys.stderr,
     )
     sys.exit(1)
+
+from . import rosdep_wrapper
 
 
 def verify_mappings():
@@ -46,9 +46,9 @@ def verify_mappings():
 
     # 2. Setup Rosdep Lookup
     try:
-        installer_context = rosdep2.create_default_installer_context()
-        lookup = rosdep2.RosdepLookup.create_from_rospkg()
-        view = lookup.get_rosdep_view(DEFAULT_VIEW_KEY)
+        installer_context = rosdep_wrapper.create_installer_context()
+        lookup = rosdep_wrapper.create_lookup_from_rospkg()
+        view = lookup.get_rosdep_view(rosdep_wrapper.get_default_view_key())
 
         # We need an OS to check against (e.g., ubuntu) to see if a rule exists
         os_name, os_version = installer_context.get_os_name_and_version()

--- a/package_xml_validation/helpers/verify_rosdep_mapping.py
+++ b/package_xml_validation/helpers/verify_rosdep_mapping.py
@@ -15,7 +15,7 @@ except ImportError:
 from . import rosdep_wrapper
 
 
-def verify_mappings():
+def verify_mappings() -> None:
     """
     Reads the cmake_rosdep_map.yaml and verifies that every target rosdep key
     exists in the local rosdep database.

--- a/package_xml_validation/helpers/verify_rosdep_mapping.py
+++ b/package_xml_validation/helpers/verify_rosdep_mapping.py
@@ -98,8 +98,8 @@ def verify_mappings() -> None:
     # 4. Reporting
     if errors:
         print("\nFound invalid mappings:")
-        for e in errors:
-            print(e)
+        for err in errors:
+            print(err)
         print("\nVerification FAILED.")
         sys.exit(1)
     else:

--- a/package_xml_validation/helpers/workspace.py
+++ b/package_xml_validation/helpers/workspace.py
@@ -15,6 +15,7 @@ import argparse
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from collections.abc import Iterable
 import os
 
 
@@ -148,7 +149,7 @@ def pkg_iterator(src_dir: Path) -> dict[str, Path]:
     return pkgs
 
 
-def get_pkgs_in_wrs(path: Path) -> list[str]:
+def get_pkgs_in_wrs(path: str | Path) -> list[str]:
     """Return all package names in the workspace that contains *path*.
 
     Args:
@@ -199,7 +200,7 @@ def _is_ignored_dir(path: Path) -> bool:
     return False
 
 
-def find_package_xml_files(paths) -> list[str]:
+def find_package_xml_files(paths: Iterable[str | Path]) -> list[str]:
     """Find all package.xml files under the provided paths.
 
     Args:

--- a/package_xml_validation/package_xml_validator.py
+++ b/package_xml_validation/package_xml_validator.py
@@ -8,7 +8,7 @@ import os
 from typing import TYPE_CHECKING
 from collections.abc import Iterable
 
-import argcomplete  # type: ignore[import-untyped]
+import argcomplete
 import lxml.etree as ET
 
 try:

--- a/package_xml_validation/package_xml_validator.py
+++ b/package_xml_validation/package_xml_validator.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 
+from __future__ import annotations
+
 import argparse
 import os
+from typing import TYPE_CHECKING
+from collections.abc import Iterable
+
+import argcomplete  # type: ignore[import-untyped]
 import lxml.etree as ET
-import argcomplete
 
 try:
     from .helpers.logger import get_logger
@@ -19,13 +24,14 @@ try:
         RosdepCheckStep,
         CMakeComparisonStep,
         LaunchDependencyStep,
+        ValidationStep,
     )
     from .helpers.workspace import find_package_xml_files
 except ImportError:
-    from helpers.logger import get_logger
-    from helpers.rosdep_validator import RosdepValidator
-    from helpers.pkg_xml_formatter import PackageXmlFormatter
-    from helpers.validation_steps import (
+    from helpers.logger import get_logger  # type: ignore[no-redef]
+    from helpers.rosdep_validator import RosdepValidator  # type: ignore[no-redef]
+    from helpers.pkg_xml_formatter import PackageXmlFormatter  # type: ignore[no-redef]
+    from helpers.validation_steps import (  # type: ignore[no-redef]
         ValidationConfig,
         FormatterValidationStep,
         BuildToolDependStep,
@@ -34,23 +40,27 @@ except ImportError:
         RosdepCheckStep,
         CMakeComparisonStep,
         LaunchDependencyStep,
+        ValidationStep,
     )
-    from helpers.workspace import find_package_xml_files
+    from helpers.workspace import find_package_xml_files  # type: ignore[no-redef]
+
+if TYPE_CHECKING:
+    from .helpers.package_types import XmlElement
 
 
 class PackageXmlValidator:
     def __init__(
         self,
-        check_only=False,
-        check_rosdeps=True,
-        compare_with_cmake=False,
-        auto_fill_missing_deps=False,
-        strict_cmake_checking=False,
-        missing_deps_only=False,
-        ignore_formatting_errors=False,
-        path=None,
-        verbose=False,
-    ):
+        check_only: bool = False,
+        check_rosdeps: bool = True,
+        compare_with_cmake: bool = False,
+        auto_fill_missing_deps: bool = False,
+        strict_cmake_checking: bool = False,
+        missing_deps_only: bool = False,
+        ignore_formatting_errors: bool = False,
+        path: str | None = None,
+        verbose: bool = False,
+    ) -> None:
         """Initialize the package.xml validator with feature flags.
 
         Args:
@@ -82,6 +92,7 @@ class PackageXmlValidator:
             self.compare_with_cmake = False
         self.strict_cmake_checking = strict_cmake_checking
         self.auto_fill_missing_deps = auto_fill_missing_deps
+        self.rosdep_validator: RosdepValidator | None = None
         if self.check_rosdeps:
             self.rosdep_validator = RosdepValidator(pkg_path=path)
         self.formatter = PackageXmlFormatter(
@@ -104,7 +115,7 @@ class PackageXmlValidator:
         self.num_checks = self._calculate_num_checks()
         self.check_count = 1
 
-    def _calculate_num_checks(self):
+    def _calculate_num_checks(self) -> int:
         """Calculate the total number of checks based on configuration.
 
         Args:
@@ -129,7 +140,7 @@ class PackageXmlValidator:
             base_checks += 1
         return base_checks
 
-    def log_check_result(self, check_name, result):
+    def log_check_result(self, check_name: str, result: bool) -> None:
         """Log the result of a check and advance the counter.
 
         Args:
@@ -152,7 +163,9 @@ class PackageXmlValidator:
         if self.check_count > self.num_checks:
             self.check_count = 1
 
-    def _build_steps(self, root, xml_file, package_name):
+    def _build_steps(
+        self, root: XmlElement, xml_file: str, package_name: str | None
+    ) -> list[ValidationStep]:
         """Build the list of validation steps for a given package.
 
         Args:
@@ -188,23 +201,28 @@ class PackageXmlValidator:
                 ]
             )
 
-        if self.check_rosdeps and not self.missing_deps_only:
+        rosdep_validator = self.rosdep_validator
+        if (
+            self.check_rosdeps
+            and not self.missing_deps_only
+            and rosdep_validator is not None
+        ):
             steps.append(
                 RosdepCheckStep(
-                    self.validation_config, self.formatter, self.rosdep_validator
+                    self.validation_config, self.formatter, rosdep_validator
                 )
             )
 
-        if self.compare_with_cmake:
+        if self.compare_with_cmake and rosdep_validator is not None:
             steps.append(
                 CMakeComparisonStep(
-                    self.validation_config, self.formatter, self.rosdep_validator
+                    self.validation_config, self.formatter, rosdep_validator
                 )
             )
 
         return steps
 
-    def check_and_format_files(self, package_xml_files):
+    def check_and_format_files(self, package_xml_files: Iterable[str]) -> bool:
         """Validate and optionally format a list of package.xml files.
 
         Args:
@@ -285,7 +303,7 @@ class PackageXmlValidator:
             )
             return True
 
-    def check_and_format(self, src):
+    def check_and_format(self, src: Iterable[str]) -> bool:
         """Find package.xml files under a path and validate them.
 
         Args:
@@ -304,7 +322,7 @@ class PackageXmlValidator:
         return self.check_and_format_files(package_xml_files)
 
 
-def main():
+def main() -> None:
     """CLI entrypoint for package.xml validation.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,13 @@ dependencies = [
     "rosdep",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "mypy",
+    "types-PyYAML",
+    "lxml-stubs",
+]
+
 [tool.setuptools]
 packages = ["package_xml_validation", "package_xml_validation.helpers"]
 
@@ -23,3 +30,35 @@ package_xml_validation = ["data/*.yaml"]
 
 [project.scripts]
 package-xml-validator = "package_xml_validation.package_xml_validator:main"
+
+[tool.mypy]
+python_version = "3.9"
+files = ["package_xml_validation"]
+# Strictness flags - everything in the package is annotated, so we can run
+# tight from the start. Stubs that may be incomplete (lxml-stubs) are why
+# we don't enable `--strict` wholesale: it would force `disallow_any_*`
+# on the lxml interop boundary.
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_unreachable = true
+no_implicit_optional = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+strict_equality = true
+
+# Untyped third-party packages. Listed explicitly (rather than
+# `ignore_missing_imports = true` globally) so a missing stub for any
+# *other* dep surfaces as a real error.
+[[tool.mypy.overrides]]
+module = ["rosdep2.*", "argcomplete.*", "regex"]
+ignore_missing_imports = true
+
+# Top-level `helpers.X` is the fallback path for the dual-import shim used
+# when the package is run as a script rather than installed. The real
+# imports go through the package-relative form; this fallback only matters
+# at runtime when sys.path is rooted at the package directory.
+[[tool.mypy.overrides]]
+module = ["helpers.*"]
+ignore_missing_imports = true


### PR DESCRIPTION

## Summary
- Annotate the full `package_xml_validation` package (validation pipeline, formatter, rosdep validator, helpers, entrypoint) and introduce an `XmlElement` `TypeAlias` for lxml elements.
- Isolate the untyped `rosdep2` dependency behind a new `helpers/rosdep_wrapper.py` so the rest of the codebase has a single, typed boundary. Lazy imports inside the wrapper preserve existing test patches and `sys.modules` swaps.
- Enable strict mypy in `pyproject.toml` and add a mypy hook in `.pre-commit-config.yaml`. Per-module `ignore_missing_imports` is scoped to `rosdep2.*`, `argcomplete.*`, `regex`, and the `helpers.*` script-mode fallback — so a missing stub for any *other* dep still surfaces as a real error.
- Fix the latent bugs mypy surfaced:
  - `None`-text `sorted()` crashes and reused-name type drift in `pkg_xml_formatter.py`
  - shadowed except-var in `verify_rosdep_mapping.py`
  - export narrowing in `BuildTypeExportStep` (`validation_steps.py`)
  - widen `LaunchDependencyStep.package_name` to `str | None` to match `formatter.get_package_name()`'s return type
  - initialize `PackageXmlValidator.rosdep_validator` to `None` up-front and narrow with explicit checks before passing to dependent steps
- Update the `verify-rosdep-map` hook to invoke `python3 -m package_xml_validation.helpers.verify_rosdep_mapping` so the new package-relative import in `rosdep_wrapper` resolves.
- Add `dev` optional-dependencies group (`mypy`, `types-PyYAML`, `lxml-stubs`) for local setup.

