### PR TITLE
Extends launch-file package detection in `find_launch_dependencies.py` to cover additional `launch_ros` constructs, and `better_launch`

### DIFF
--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -23,21 +23,46 @@ REGEX_EXPR = [
     r"pkg\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
     # Hector launch component:  package: <pkg_name>
     r"package\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
-    # Python Node call: Node(..., package='<pkg_name>', ...)
-    r"Node\s*\(\s*[^)]*?package\s*=\s*['\"]([A-Za-z0-9_]+)['\"]",
+    # Python Node-family constructors: Node / LifecycleNode / ComposableNode /
+    # ComposableLifecycleNode (..., package='<pkg_name>', ...)
+    r"(?:^|[^\w])(?:Node|LifecycleNode|ComposableNode|ComposableLifecycleNode)\s*\(\s*[^)]*?\bpackage\s*=\s*['\"]([A-Za-z0-9_]+)['\"]",
     # XML node tag: <node pkg="foo" ...>
     r"<node[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    # XML composable node: <composable_node pkg="foo" ...>
+    r"<composable_node[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    # XML node container: <node_container pkg="foo" ...>
+    r"<node_container[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
     # get_package_share_directory('foo')
     r"get_package_share_directory\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    # get_package_share_path('foo')
+    r"get_package_share_path\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    # get_package_prefix('foo')
+    r"get_package_prefix\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
     # FindPackageShare('foo')
     r"FindPackageShare\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
     # FindPackageShare(package='foo')
     r"FindPackageShare\(\s*package\s*=\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    # FindPackagePrefix('foo') / FindPackagePrefix(package='foo')
+    r"FindPackagePrefix\(\s*(?:package\s*=\s*)?['\"]([A-Za-z0-9_]+)['\"]\s*\)",
     # $(find-pkg-share foo)
     r"\$\(\s*find-pkg-share\s+([A-Za-z0-9_]+)\s*\)",
+    # $(find-pkg-prefix foo)
+    r"\$\(\s*find-pkg-prefix\s+([A-Za-z0-9_]+)\s*\)",
+    # better_launch Python:  bl.node("pkg", ...)  /  bl.include("pkg", ...)
+    r"\bbl\.node\(\s*['\"]([A-Za-z0-9_]+)['\"]",
+    r"\bbl\.include\(\s*['\"]([A-Za-z0-9_]+)['\"]",
 ]
 
 COMPILED = [re.compile(rx) for rx in REGEX_EXPR]
+
+# TOML patterns are kept separate and only applied to .toml files under a
+# launch/ directory, to avoid false positives from arbitrary TOML configs.
+TOML_REGEX_EXPR = [
+    # better_launch TOML:  package = "pkg"
+    r"^\s*package\s*=\s*['\"]([A-Za-z0-9_]+)['\"]",
+]
+
+TOML_COMPILED = [re.compile(rx, re.MULTILINE) for rx in TOML_REGEX_EXPR]
 
 _TRIPLE_QUOTE_BLOCK = re.compile(r"(?s)(['\"]{3})(?:.*?)(\1)")
 _XML_COMMENT_BLOCK = re.compile(r"(?s)<!--.*?-->")
@@ -148,6 +173,19 @@ def _decomment_yaml(text: str) -> str:
     return _strip_hash_line_comments_outside_strings(text)
 
 
+def _decomment_toml(text: str) -> str:
+    """Remove TOML hash comments outside strings.
+
+    Args:
+        text: TOML source text.
+
+    Returns:
+        Text with comments removed.
+
+    """
+    return _strip_hash_line_comments_outside_strings(text)
+
+
 def _decomment_for_suffix(suffix: str, text: str) -> str:
     """Strip comments based on file suffix.
 
@@ -166,8 +204,24 @@ def _decomment_for_suffix(suffix: str, text: str) -> str:
         return _decomment_xml(text)
     if s.endswith(".yaml") or s.endswith(".yml"):
         return _decomment_yaml(text)
+    if s.endswith(".toml"):
+        return _decomment_toml(text)
     # default: no decommenting
     return text
+
+
+def _is_under_launch_dir(path: str) -> bool:
+    """Return True if any path component (excluding the basename) is named 'launch'.
+
+    Args:
+        path: File path to inspect.
+
+    Returns:
+        Whether the file lives under a 'launch' directory at any depth.
+
+    """
+    parts = os.path.normpath(path).split(os.sep)
+    return "launch" in parts[:-1]
 
 
 def scan_file(path: str, found: set[str], verbose: bool = False) -> None:
@@ -187,7 +241,19 @@ def scan_file(path: str, found: set[str], verbose: bool = False) -> None:
 
     text = _decomment_for_suffix(path, text)
 
-    for i, rx in enumerate(COMPILED):
+    is_toml = path.lower().endswith(".toml")
+    if is_toml:
+        # Only honour TOML matches if the file is scoped under a launch/ dir,
+        # to avoid false positives from arbitrary project TOML configs.
+        if not _is_under_launch_dir(path):
+            return
+        patterns = TOML_COMPILED
+        sources = TOML_REGEX_EXPR
+    else:
+        patterns = COMPILED
+        sources = REGEX_EXPR
+
+    for i, rx in enumerate(patterns):
         for m in rx.finditer(text):
             pkg = m.group(1)
             found.add(pkg)
@@ -196,7 +262,7 @@ def scan_file(path: str, found: set[str], verbose: bool = False) -> None:
                     "Found package '%s' in %s with regex %s",
                     pkg,
                     os.path.basename(path),
-                    REGEX_EXPR[i],
+                    sources[i],
                 )
 
 
@@ -223,6 +289,9 @@ def scan_files(launch_dir: str, verbose: bool = False) -> list[str]:
 
     for root, _, files in os.walk(launch_dir):
         for fn in files:
+            full = os.path.join(root, fn)
             if fn.endswith((".py", ".xml", ".yaml", ".launch", ".yml")):
-                scan_file(os.path.join(root, fn), pkgs, verbose)
+                scan_file(full, pkgs, verbose)
+            elif fn.endswith(".toml") and _is_under_launch_dir(full):
+                scan_file(full, pkgs, verbose)
     return sorted(pkgs)

--- a/tests/examples/launch_examples/better_launch_example.launch.py
+++ b/tests/examples/launch_examples/better_launch_example.launch.py
@@ -1,0 +1,7 @@
+import better_launch as bl
+
+
+def generate_launch_description():
+    # bl.node("ignored_pkg", "ignored_exec")
+    bl.node("bl_pkg_a", "talker")
+    bl.include("bl_pkg_b", "child.launch.py")

--- a/tests/examples/launch_examples/better_launch_toml/config/not_a_launch.toml
+++ b/tests/examples/launch_examples/better_launch_toml/config/not_a_launch.toml
@@ -1,0 +1,2 @@
+[some_section]
+package = "must_not_match"

--- a/tests/examples/launch_examples/better_launch_toml/launch/example.launch.toml
+++ b/tests/examples/launch_examples/better_launch_toml/launch/example.launch.toml
@@ -1,0 +1,4 @@
+[some_node]
+package = "toml_pkg_a"
+filename = "thing.launch.py"
+# package = "should_be_ignored"

--- a/tests/examples/launch_examples/python_composable_nodes.launch.py
+++ b/tests/examples/launch_examples/python_composable_nodes.launch.py
@@ -1,0 +1,26 @@
+from launch import LaunchDescription
+from launch_ros.actions import LifecycleNode, LoadComposableNodes
+from launch_ros.descriptions import ComposableNode
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            LoadComposableNodes(
+                target_container="my_container",
+                composable_node_descriptions=[
+                    ComposableNode(
+                        package="image_proc",
+                        plugin="image_proc::RectifyNode",
+                        name="rectify",
+                    ),
+                ],
+            ),
+            LifecycleNode(
+                package="lifecycle_demo",
+                executable="lifecycle_talker",
+                name="talker",
+                namespace="",
+            ),
+        ]
+    )

--- a/tests/examples/launch_examples/python_find_package_prefix.launch.py
+++ b/tests/examples/launch_examples/python_find_package_prefix.launch.py
@@ -1,0 +1,13 @@
+from ament_index_python.packages import get_package_prefix, get_package_share_path
+from launch import LaunchDescription
+from launch_ros.substitutions import FindPackagePrefix
+
+
+def generate_launch_description():
+    prefix_a = FindPackagePrefix("foo_pkg")
+    prefix_b = FindPackagePrefix(package="bar_pkg")
+    share_path = get_package_share_path("baz_pkg")
+    install_prefix = get_package_prefix("qux_pkg")
+
+    _ = (prefix_a, prefix_b, share_path, install_prefix)
+    return LaunchDescription([])

--- a/tests/examples/launch_examples/xml_composable_container.launch.xml
+++ b/tests/examples/launch_examples/xml_composable_container.launch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <!-- <composable_node pkg="ignored" plugin="x"/> -->
+  <node_container pkg="cont_b" exec="component_container" name="my_container" namespace="">
+    <composable_node pkg="comp_a" plugin="comp_a::DoThing" name="thing"/>
+  </node_container>
+  <include file="$(find-pkg-prefix find_prefix_pkg)/share/find_prefix_pkg/launch/child.launch.xml"/>
+</launch>

--- a/tests/test_find_launch_dependencies.py
+++ b/tests/test_find_launch_dependencies.py
@@ -33,6 +33,19 @@ class TestFindLaunchDependencies(unittest.TestCase):
         ],
         "python_example_bad.launch.py": [],  # ["demo_nodes_cpp", "turtlesim"],
         "yaml_example_bad.launch.yml": [],  # ["demo_nodes_cpp", "turtlesim"],
+        "python_composable_nodes.launch.py": ["image_proc", "lifecycle_demo"],
+        "python_find_package_prefix.launch.py": [
+            "foo_pkg",
+            "bar_pkg",
+            "baz_pkg",
+            "qux_pkg",
+        ],
+        "xml_composable_container.launch.xml": [
+            "comp_a",
+            "cont_b",
+            "find_prefix_pkg",
+        ],
+        "better_launch_example.launch.py": ["bl_pkg_a", "bl_pkg_b"],
     }
 
     # Directory where example launch files live
@@ -72,6 +85,20 @@ class TestFindLaunchDependencies(unittest.TestCase):
         )
         found = scan_files(existing_file)
         self.assertEqual(len(found), 0)
+
+    def test_scan_directory_with_toml(self):
+        """better_launch .toml files under a launch/ dir contribute deps; .toml
+        outside a launch/ dir must not."""
+        pkg_dir = os.path.join(
+            os.path.dirname(__file__),
+            "examples",
+            "launch_examples",
+            "better_launch_toml",
+        )
+        found = set(scan_files(pkg_dir))
+        self.assertIn("toml_pkg_a", found)
+        self.assertNotIn("should_be_ignored", found)
+        self.assertNotIn("must_not_match", found)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Added more common `launch_ros` package identifiers to the launch dependency scanner (composable nodes, `FindPackagePrefix` / `find-pkg-prefix`, `get_package_share_path`, `get_package_prefix`, etc.).
- Added syntax to support `better_launch` launch files in Python (`bl.node` / `bl.include`).
- Added scoped support for `better_launch` TOML launch files (only `.toml` files under a `launch/` directory contribute deps, to avoid false positives from project config TOMLs).
