### PR TITLE
Add regression-guard tests for validation steps, CMake parser, and ro…

### DIFF
--- a/tests/test_build_type_export_step.py
+++ b/tests/test_build_type_export_step.py
@@ -80,5 +80,89 @@ class TestBuildTypeExportStepUnknownType(unittest.TestCase):
         formatter.add_build_type_export.assert_not_called()
 
 
+class TestBuildTypeExportStepCMakePackage(unittest.TestCase):
+    """Tests for a CMake pkg (``CMakeLists.txt`` present). The expected
+    ``<export><build_type>`` is ``ament_cmake``; the step must report or
+    auto-fill missing/incorrect entries depending on the config flags.
+    """
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="build_type_cmake_"))
+        self.pkg_dir = self.tmpdir / "cmake_pkg"
+        self.pkg_dir.mkdir()
+        (self.pkg_dir / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.5)\n"
+        )
+        self.xml_file = str(self.pkg_dir / "package.xml")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _root_with_wrong_build_type(self) -> ET._Element:
+        return ET.fromstring(
+            b"<package format='3'>"
+            b"<name>x</name>"
+            b"<export><build_type>ament_python</build_type></export>"
+            b"</package>"
+        )
+
+    def test_check_only_missing_export_reports_error(self):
+        formatter = MagicMock()
+        step = BuildTypeExportStep(_config(check_only=True), formatter)
+        root = _root_without_export()
+
+        result = step.perform_check(root, self.xml_file)
+
+        self.assertFalse(result.valid)
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("Missing <export> tag", result.errors[0])
+        self.assertEqual(result.critical_errors, [])
+        formatter.add_build_type_export.assert_not_called()
+
+    def test_check_only_wrong_build_type_reports_error(self):
+        formatter = MagicMock()
+        step = BuildTypeExportStep(_config(check_only=True), formatter)
+        root = self._root_with_wrong_build_type()
+
+        result = step.perform_check(root, self.xml_file)
+
+        self.assertFalse(result.valid)
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("Incorrect <build_type>", result.errors[0])
+        formatter.add_build_type_export.assert_not_called()
+
+    def test_no_auto_fill_yields_critical_error(self):
+        """``check_only=False`` and ``auto_fill_missing_deps=False`` is
+        the "can't fix it for you, but it must be fixed" path."""
+        formatter = MagicMock()
+        step = BuildTypeExportStep(
+            _config(check_only=False, auto_fill_missing_deps=False), formatter
+        )
+        root = _root_without_export()
+
+        result = step.perform_check(root, self.xml_file)
+
+        self.assertFalse(result.valid)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(len(result.critical_errors), 1)
+        self.assertIn("Cannot auto-fill", result.critical_errors[0])
+        formatter.add_build_type_export.assert_not_called()
+
+    def test_auto_fill_inserts_and_marks_changed(self):
+        formatter = MagicMock()
+        step = BuildTypeExportStep(
+            _config(check_only=False, auto_fill_missing_deps=True), formatter
+        )
+        root = _root_without_export()
+
+        result = step.perform_check(root, self.xml_file)
+
+        self.assertFalse(result.valid)
+        self.assertTrue(result.changed)
+        self.assertEqual(len(result.warnings), 1)
+        self.assertIn("Auto-filling", result.warnings[0])
+        formatter.add_build_type_export.assert_called_once_with(root, "ament_cmake")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cmake_comparison_step_unit.py
+++ b/tests/test_cmake_comparison_step_unit.py
@@ -1,0 +1,218 @@
+"""Unit tests for ``CMakeComparisonStep`` branches not covered by the
+end-to-end ``PackageXmlValidator`` tests in ``test_cmake_comparison.py``."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import lxml.etree as ET
+
+from package_xml_validation.helpers.exception_parser import DependencyExceptions
+from package_xml_validation.helpers.package_types import PackageType
+from package_xml_validation.helpers.pkg_xml_formatter import PackageXmlFormatter
+from package_xml_validation.helpers.validation_steps import ValidationConfig
+from package_xml_validation.helpers.validation_steps.cmake_comparison_step import (
+    CMakeComparisonStep,
+)
+
+
+def _config(**overrides):
+    base = {
+        "check_only": False,
+        "auto_fill_missing_deps": False,
+        "check_rosdeps": True,
+        "compare_with_cmake": True,
+        "strict_cmake_checking": False,
+        "missing_deps_only": False,
+        "ignore_formatting_errors": False,
+    }
+    base.update(overrides)
+    return ValidationConfig(**base)
+
+
+def _parse(xml: str):
+    return ET.fromstring(xml.encode("utf-8"))
+
+
+_CMAKE_PKG_XML = """<?xml version="1.0"?>
+<package format="3">
+  <name>demo</name>
+  <version>0.0.1</version>
+  <description>demo</description>
+  <maintainer email="a@example.com">a</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+</package>
+"""
+
+
+class _CMakePkgFixture:
+    """Helper that lays out a fake CMake pkg dir (package.xml + optional
+    CMakeLists.txt). ``cleanup`` removes the temp tree."""
+
+    def __init__(self, with_cmakelists: bool, cmake_body: str = "") -> None:
+        self.root = tempfile.mkdtemp(prefix="cmake_cmp_step_")
+        self.pkg_dir = os.path.join(self.root, "demo")
+        os.makedirs(self.pkg_dir)
+        self.xml_path = os.path.join(self.pkg_dir, "package.xml")
+        with open(self.xml_path, "w", encoding="utf-8") as f:
+            f.write(_CMAKE_PKG_XML)
+        if with_cmakelists:
+            with open(
+                os.path.join(self.pkg_dir, "CMakeLists.txt"), "w", encoding="utf-8"
+            ) as f:
+                f.write(cmake_body)
+
+    def cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+def _make_step(config: ValidationConfig, rosdep_validator: MagicMock):
+    formatter = PackageXmlFormatter(check_only=config.check_only)
+    return CMakeComparisonStep(
+        config=config,
+        formatter=formatter,
+        rosdep_validator=rosdep_validator,
+        exceptions=DependencyExceptions(),
+    )
+
+
+class TestMissingCMakeLists(unittest.TestCase):
+    """Item 1: the branch where a CMake pkg has no ``CMakeLists.txt``.
+
+    In practice ``get_package_type`` derives the type *from* the presence
+    of ``CMakeLists.txt``, so this branch is reachable only when a caller
+    forces ``PackageType.CMAKE_PKG`` for a directory that happens to be
+    missing the file. We patch ``get_package_type`` accordingly to
+    exercise the error/auto-fill messaging the step defines.
+    """
+
+    def _force_cmake_pkg_type(self):
+        return patch(
+            "package_xml_validation.helpers.validation_steps."
+            "cmake_comparison_step.get_package_type",
+            return_value=(PackageType.CMAKE_PKG, False),
+        )
+
+    def test_missing_cmakelists_reports_critical_error_when_not_auto_filling(self):
+        fixture = _CMakePkgFixture(with_cmakelists=False)
+        self.addCleanup(fixture.cleanup)
+
+        step = _make_step(
+            _config(auto_fill_missing_deps=False, check_only=True),
+            MagicMock(),
+        )
+        with self._force_cmake_pkg_type():
+            result = step.perform_check(_parse(_CMAKE_PKG_XML), fixture.xml_path)
+
+        self.assertFalse(result.valid)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(len(result.critical_errors), 1)
+        self.assertIn("does not exist", result.critical_errors[0])
+
+    def test_missing_cmakelists_reports_error_when_auto_filling(self):
+        fixture = _CMakePkgFixture(with_cmakelists=False)
+        self.addCleanup(fixture.cleanup)
+
+        step = _make_step(
+            _config(auto_fill_missing_deps=True, check_only=False),
+            MagicMock(),
+        )
+        with self._force_cmake_pkg_type():
+            result = step.perform_check(_parse(_CMAKE_PKG_XML), fixture.xml_path)
+
+        self.assertFalse(result.valid)
+        self.assertEqual(result.critical_errors, [])
+        self.assertEqual(len(result.errors), 1)
+        self.assertIn("does not exist", result.errors[0])
+
+
+class TestUnresolvedDepReporting(unittest.TestCase):
+    """Item 2: strict-vs-non-strict reporting for deps that can't be
+    resolved and (optionally) have rosdep search candidates."""
+
+    def _fixture_with_dep(self) -> _CMakePkgFixture:
+        # CMake file exposes a single dep "Frobnicator" that the rosdep
+        # validator will refuse to resolve.
+        body = "find_package(Frobnicator REQUIRED)\n"
+        return _CMakePkgFixture(with_cmakelists=True, cmake_body=body)
+
+    def test_unresolved_dep_with_candidates_strict_is_critical_error(self):
+        fixture = self._fixture_with_dep()
+        self.addCleanup(fixture.cleanup)
+
+        rosdep = MagicMock()
+        rosdep.resolve_cmake_dependency.return_value = None
+        rosdep.search_rosdep_candidates.return_value = ["foo_alt", "bar_alt"]
+
+        step = _make_step(_config(strict_cmake_checking=True), rosdep)
+        result = step.perform_check(_parse(_CMAKE_PKG_XML), fixture.xml_path)
+
+        self.assertFalse(result.valid)
+        self.assertEqual(result.warnings, [])
+        self.assertEqual(len(result.critical_errors), 1)
+        msg = result.critical_errors[0]
+        self.assertIn("Frobnicator", msg)
+        self.assertIn("rosdep search candidates: foo_alt, bar_alt", msg)
+
+    def test_unresolved_dep_without_candidates_non_strict_is_warning(self):
+        fixture = self._fixture_with_dep()
+        self.addCleanup(fixture.cleanup)
+
+        rosdep = MagicMock()
+        rosdep.resolve_cmake_dependency.return_value = None
+        rosdep.search_rosdep_candidates.return_value = []
+
+        step = _make_step(_config(strict_cmake_checking=False), rosdep)
+        result = step.perform_check(_parse(_CMAKE_PKG_XML), fixture.xml_path)
+
+        # Warnings-only path leaves result.valid untouched (defaults True).
+        self.assertTrue(result.valid)
+        self.assertEqual(result.critical_errors, [])
+        self.assertEqual(len(result.warnings), 1)
+        msg = result.warnings[0]
+        self.assertIn("Frobnicator", msg)
+        self.assertIn("via rosdep resolve, mapping, or rosdep search", msg)
+
+
+class TestEvaluateConditionsFallback(unittest.TestCase):
+    """Item 3: with ``evaluate_conditions=False`` the step must read deps
+    via the formatter rather than the condition-aware queries."""
+
+    def test_evaluate_conditions_false_uses_formatter_retrieve(self):
+        body = "find_package(rclcpp REQUIRED)\n"
+        fixture = _CMakePkgFixture(with_cmakelists=True, cmake_body=body)
+        self.addCleanup(fixture.cleanup)
+
+        rosdep = MagicMock()
+        # Pretend every CMake dep resolves to itself so the step doesn't
+        # bail out before it inspects the xml-side deps.
+        rosdep.resolve_cmake_dependency.side_effect = lambda x: x
+        rosdep.search_rosdep_candidates.return_value = []
+
+        config = _config(evaluate_conditions=False)
+        formatter = PackageXmlFormatter(check_only=config.check_only)
+        formatter.retrieve_build_dependencies = MagicMock(return_value=["rclcpp"])
+        formatter.retrieve_test_dependencies = MagicMock(return_value=[])
+
+        step = CMakeComparisonStep(
+            config=config,
+            formatter=formatter,
+            rosdep_validator=rosdep,
+            exceptions=DependencyExceptions(),
+        )
+        root = _parse(_CMAKE_PKG_XML)
+        result = step.perform_check(root, fixture.xml_path)
+
+        formatter.retrieve_build_dependencies.assert_called_once_with(root)
+        formatter.retrieve_test_dependencies.assert_called_once_with(root)
+        # rclcpp is in the xml-side list, so no missing-dep complaints.
+        self.assertEqual(result.critical_errors, [])
+        self.assertEqual(result.errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cmake_parser.py
+++ b/tests/test_cmake_parser.py
@@ -1,7 +1,11 @@
 import os
 import unittest
 
-from package_xml_validation.helpers.cmake_parsers import read_deps_from_cmake_file
+from package_xml_validation.helpers.cmake_parsers import (
+    read_deps_from_cmake_file,
+    resolve_for_each,
+    retrieve_cmake_dependencies,
+)
 
 # This test suite validates the CMake parser against known CMakeLists.txt examples.
 # The examples are stored in the 'data/cmake_examples' directory.
@@ -88,6 +92,88 @@ class TestCMakeParser(unittest.TestCase):
                 for dep in expected.get("absent", []):
                     self.assertNotIn(dep, main_deps)
                     self.assertNotIn(dep, test_deps)
+
+
+class TestFindPackageQuietRule(unittest.TestCase):
+    """``find_package(... QUIET)`` without ``REQUIRED`` is optional — the
+    build does not fail if the package is missing, so the parser must
+    not report it as a dep. Adding ``REQUIRED`` flips the behaviour."""
+
+    def test_quiet_without_required_is_skipped(self):
+        lines = ["find_package(OptionalPkg QUIET)"]
+        main_deps, test_deps = retrieve_cmake_dependencies(lines)
+        self.assertEqual(main_deps, [])
+        self.assertEqual(test_deps, [])
+
+    def test_quiet_with_required_is_kept(self):
+        lines = ["find_package(MustHavePkg QUIET REQUIRED)"]
+        main_deps, _ = retrieve_cmake_dependencies(lines)
+        self.assertEqual(main_deps, ["MustHavePkg"])
+
+    def test_required_without_quiet_is_kept(self):
+        lines = ["find_package(NeededPkg REQUIRED)"]
+        main_deps, _ = retrieve_cmake_dependencies(lines)
+        self.assertEqual(main_deps, ["NeededPkg"])
+
+
+class TestResolveForEach(unittest.TestCase):
+    """``resolve_for_each`` expands ``foreach(... IN LISTS/ITEMS ...)``
+    blocks so dependencies declared inside loops are still discovered.
+    These are pure-input/pure-output transformations on CMake lines."""
+
+    def test_foreach_in_lists_expands_set_variable(self):
+        input_lines = [
+            "set(LIBS a b c)",
+            "foreach(L IN LISTS LIBS)",
+            "find_package(${L} REQUIRED)",
+            "endforeach()",
+        ]
+        expanded = resolve_for_each(input_lines)
+        # Loop-body lines are replicated once per value, with the loop
+        # variable substituted in place of ``${L}``.
+        self.assertIn("find_package(a REQUIRED)", expanded)
+        self.assertIn("find_package(b REQUIRED)", expanded)
+        self.assertIn("find_package(c REQUIRED)", expanded)
+
+    def test_foreach_expansion_round_trips_through_retrieve(self):
+        """End-to-end: foreach-driven find_package calls become deps."""
+        lines = [
+            "set(LIBS Alpha Beta)",
+            "foreach(L IN LISTS LIBS)",
+            "find_package(${L} REQUIRED)",
+            "endforeach()",
+        ]
+        # The retrieve step does not call resolve_for_each on its own;
+        # callers chain them via read_cmake_file. So we run it explicitly.
+        expanded = resolve_for_each(lines)
+        main_deps, _ = retrieve_cmake_dependencies(expanded)
+        self.assertCountEqual(main_deps, ["Alpha", "Beta"])
+
+    def test_foreach_in_items_uses_inline_values(self):
+        """``IN ITEMS`` accepts a bare identifier; the regex requires it
+        to look like a variable name, so this exercises the
+        ``variables.get(..., [])`` fallback when the name isn't a
+        previously ``set()`` variable."""
+        input_lines = [
+            "foreach(P IN ITEMS unknown_var)",
+            "find_package(${P} REQUIRED)",
+            "endforeach()",
+        ]
+        expanded = resolve_for_each(input_lines)
+        # With no matching set(), the loop body is emitted unchanged
+        # (the empty value list produces zero replications, leaving only
+        # any non-template lines). This pins the don't-crash behaviour.
+        self.assertNotIn("find_package(unknown_var REQUIRED)", expanded)
+
+    def test_lines_outside_foreach_are_passed_through_verbatim(self):
+        input_lines = [
+            "find_package(rclcpp REQUIRED)",
+            "set(IGNORED x)",
+            "find_package(std_msgs REQUIRED)",
+        ]
+        expanded = resolve_for_each(input_lines)
+        self.assertIn("find_package(rclcpp REQUIRED)", expanded)
+        self.assertIn("find_package(std_msgs REQUIRED)", expanded)
 
 
 if __name__ == "__main__":

--- a/tests/test_find_launch_dependencies.py
+++ b/tests/test_find_launch_dependencies.py
@@ -100,6 +100,23 @@ class TestFindLaunchDependencies(unittest.TestCase):
         self.assertNotIn("should_be_ignored", found)
         self.assertNotIn("must_not_match", found)
 
+    def test_scan_file_toml_outside_launch_dir_is_skipped(self):
+        """Direct ``scan_file`` call on a TOML file living outside a
+        ``launch/`` directory must not contribute any packages, even when
+        the contents would otherwise match the TOML regex."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="toml_outside_launch_") as tmp:
+            config_dir = os.path.join(tmp, "config")
+            os.makedirs(config_dir)
+            toml_path = os.path.join(config_dir, "stuff.toml")
+            with open(toml_path, "w", encoding="utf-8") as f:
+                f.write('package = "should_not_be_found"\n')
+
+            found: set[str] = set()
+            scan_file(toml_path, found)
+            self.assertEqual(found, set())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_package_xml_validator_init.py
+++ b/tests/test_package_xml_validator_init.py
@@ -1,0 +1,74 @@
+"""Tests for ``PackageXmlValidator`` constructor flag interactions and
+its handling of malformed input files. These paths are not exercised by
+the higher-level integration tests in ``test_cmake_comparison.py``
+because that suite always passes well-formed package.xml inputs and
+constructs the validator with both ``check_rosdeps=True`` and
+``compare_with_cmake=True``."""
+
+import os
+import tempfile
+import unittest
+
+from package_xml_validation.package_xml_validator import PackageXmlValidator
+
+_VALIDATOR_LOGGER_NAME = "package_xml_validation.package_xml_validator"
+
+
+class TestPackageXmlValidatorInit(unittest.TestCase):
+    """Item 9: the constructor must silently disable ``compare_with_cmake``
+    when ``check_rosdeps`` is False, emitting one warning explaining why."""
+
+    def test_compare_with_cmake_without_check_rosdeps_is_disabled_with_warning(self):
+        with self.assertLogs(_VALIDATOR_LOGGER_NAME, level="WARNING") as captured:
+            validator = PackageXmlValidator(
+                check_only=True,
+                check_rosdeps=False,
+                compare_with_cmake=True,
+            )
+        self.assertFalse(validator.compare_with_cmake)
+        self.assertTrue(
+            any(
+                "Comparing with CMake but not checking ROS dependencies" in record
+                for record in captured.output
+            ),
+            f"Expected warning not found in {captured.output!r}",
+        )
+
+
+class TestPackageXmlValidatorMalformedXml(unittest.TestCase):
+    """Item 10: a malformed package.xml must not crash the run; the
+    validator records ``xml_valid=False`` for that file, sets
+    ``all_valid=False``, logs the parse error, and continues."""
+
+    def test_malformed_package_xml_marks_invalid_and_continues(self):
+        with tempfile.TemporaryDirectory(prefix="malformed_pkg_xml_") as tmp:
+            pkg_dir = os.path.join(tmp, "demo")
+            os.makedirs(pkg_dir)
+            xml_path = os.path.join(pkg_dir, "package.xml")
+            with open(xml_path, "w", encoding="utf-8") as f:
+                # Deliberately unclosed element — ET.parse must raise
+                # ET.XMLSyntaxError, which the validator catches.
+                f.write("<package><name>oops")
+
+            validator = PackageXmlValidator(
+                check_only=True,
+                check_rosdeps=False,
+                compare_with_cmake=False,
+            )
+
+            with self.assertLogs(_VALIDATOR_LOGGER_NAME, level="ERROR") as captured:
+                all_valid = validator.check_and_format_files([xml_path])
+
+            self.assertFalse(all_valid)
+            self.assertFalse(validator.xml_valid)
+            self.assertFalse(validator.all_valid)
+            self.assertTrue(
+                any(
+                    f"Error parsing {xml_path}" in record for record in captured.output
+                ),
+                f"Expected parse-error log not found in {captured.output!r}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pkg_xml_formatter_edge_cases.py
+++ b/tests/test_pkg_xml_formatter_edge_cases.py
@@ -122,5 +122,43 @@ class TestSiblingSeparationMessages(unittest.TestCase):
         self.assertIn("more than one blank line", joined)
 
 
+class TestResolveIndentation(unittest.TestCase):
+    """``resolve_indentation`` exposes three fallback branches that
+    callers rely on when a tree is malformed or freshly constructed."""
+
+    def test_returns_default_when_root_is_empty(self):
+        from package_xml_validation.helpers.formatter.indentation import (
+            resolve_indentation,
+        )
+
+        root = ET.fromstring(b'<package format="3"/>')
+        self.assertEqual(resolve_indentation(root), "  ")
+        self.assertEqual(resolve_indentation(root, default="\t"), "\t")
+
+    def test_returns_default_when_first_child_tail_is_none(self):
+        from package_xml_validation.helpers.formatter.indentation import (
+            resolve_indentation,
+        )
+
+        # Build a tree where the first child has tail=None explicitly.
+        root = ET.Element("package")
+        child = ET.SubElement(root, "name")
+        child.text = "demo"
+        # lxml's default tail for a SubElement is None.
+        self.assertIsNone(child.tail)
+        self.assertEqual(resolve_indentation(root), "  ")
+
+    def test_returns_full_tail_when_no_newline(self):
+        from package_xml_validation.helpers.formatter.indentation import (
+            resolve_indentation,
+        )
+
+        root = ET.Element("package")
+        child = ET.SubElement(root, "name")
+        child.text = "demo"
+        child.tail = "   "  # whitespace-only, no newline
+        self.assertEqual(resolve_indentation(root), "   ")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rodep_validator.py
+++ b/tests/test_rodep_validator.py
@@ -239,6 +239,11 @@ class TestRosdepValidator(unittest.TestCase):
         # Both candidates appear in the (deduped) result set.
         self.assertEqual(sorted(r.lower() for r in results), ["boost", "boost"])
 
+    @unittest.skipUnless(
+        SUT.HAS_REGEX_MODULE,
+        "fuzzy-vs-substring tier ordering only applies when the optional "
+        "`regex` package is installed; the `re` fallback is substring-only",
+    )
     def test_search_candidates_orders_contains_before_fuzzy(self):
         """Tier 1 (substring) must beat tier 3 (fuzzy similarity) even
         when the fuzzy candidate has a higher difflib ratio overall."""

--- a/tests/test_rodep_validator.py
+++ b/tests/test_rodep_validator.py
@@ -206,6 +206,91 @@ class TestRosdepValidator(unittest.TestCase):
 
         self.assertEqual(missing, ["invalid_lib"])
 
+    def _make_source(self, data):
+        """Build a mock that satisfies the ``CachedDataSource`` isinstance
+        check inside ``search_rosdep_candidates`` and carries the supplied
+        rosdep_data payload."""
+        from rosdep2.sources_list import CachedDataSource
+
+        src = MagicMock()
+        src.__class__ = CachedDataSource
+        src.rosdep_data = data
+        return src
+
+    def test_search_candidates_orders_exact_match_first(self):
+        """Tier 0 must beat tier 1: an exact match outranks substring
+        containment regardless of the substring candidate's length."""
+        validator = SUT.RosdepValidator()
+        src = self._make_source(
+            {
+                # Substring container (tier 1) — short, would win on length alone
+                "boost": {"ubuntu": "boost"},
+                # Exact match (tier 0) — must come first
+                "Boost": {"ubuntu": "libboost-all-dev"},
+            }
+        )
+        self.mock_sources_loader.get_loadable_views.return_value = ["s1"]
+        self.mock_sources_loader.get_source.return_value = src
+
+        results = validator.search_rosdep_candidates("Boost")
+        # Compare case-insensitively at the lower-cased boundary the sort
+        # uses; the first hit must be the exact-case match.
+        self.assertEqual(results[0].lower(), "boost")
+        # Both candidates appear in the (deduped) result set.
+        self.assertEqual(sorted(r.lower() for r in results), ["boost", "boost"])
+
+    def test_search_candidates_orders_contains_before_fuzzy(self):
+        """Tier 1 (substring) must beat tier 3 (fuzzy similarity) even
+        when the fuzzy candidate has a higher difflib ratio overall."""
+        validator = SUT.RosdepValidator()
+        src = self._make_source(
+            {
+                # Tier 1: contains "threads"
+                "ecl_threads": {"ubuntu": "ecl-threads"},
+                # Tier 3: fuzzy-only match — does NOT contain "threads"
+                # but is close enough (1 edit) that the `regex` module's
+                # error-tolerant pattern will match.
+                "thread": {"ubuntu": "thread"},
+            }
+        )
+        self.mock_sources_loader.get_loadable_views.return_value = ["s1"]
+        self.mock_sources_loader.get_source.return_value = src
+
+        results = validator.search_rosdep_candidates("threads")
+        self.assertIn("ecl_threads", results)
+        # The contains-match must precede the fuzzy-only match.
+        self.assertLess(results.index("ecl_threads"), results.index("thread"))
+
+    def test_search_candidates_shorter_contains_match_wins(self):
+        """Within tier 1, a shorter candidate is preferred (length
+        secondary key)."""
+        validator = SUT.RosdepValidator()
+        src = self._make_source(
+            {
+                "libboost-all-dev": {"ubuntu": "libboost-all-dev"},
+                "libboost": {"ubuntu": "libboost"},
+            }
+        )
+        self.mock_sources_loader.get_loadable_views.return_value = ["s1"]
+        self.mock_sources_loader.get_source.return_value = src
+
+        results = validator.search_rosdep_candidates("boost")
+        # Both contain "boost"; the shorter key comes first.
+        self.assertEqual(results[0], "libboost")
+        self.assertIn("libboost-all-dev", results)
+
+    def test_search_candidates_caps_at_five_results(self):
+        """The function deliberately truncates to 5 matches to keep
+        suggestion messages readable."""
+        validator = SUT.RosdepValidator()
+        data = {f"boost-flavor-{i}": {"ubuntu": f"boost-{i}"} for i in range(10)}
+        src = self._make_source(data)
+        self.mock_sources_loader.get_loadable_views.return_value = ["s1"]
+        self.mock_sources_loader.get_source.return_value = src
+
+        results = validator.search_rosdep_candidates("boost")
+        self.assertEqual(len(results), 5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rosdep_check_step.py
+++ b/tests/test_rosdep_check_step.py
@@ -1,0 +1,97 @@
+"""Unit tests for ``RosdepCheckStep`` early-return branches.
+
+The step has two early-exit paths that are not exercised by any other
+test suite: the config-flag check at the top, and the empty-deps check
+after dependency retrieval. These tests pin both behaviours so future
+refactors can't silently swallow the gate."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+import lxml.etree as ET
+
+from package_xml_validation.helpers.pkg_xml_formatter import PackageXmlFormatter
+from package_xml_validation.helpers.validation_steps import ValidationConfig
+from package_xml_validation.helpers.validation_steps.rosdep_check_step import (
+    RosdepCheckStep,
+)
+
+
+def _config(**overrides):
+    base = {
+        "check_only": True,
+        "auto_fill_missing_deps": False,
+        "check_rosdeps": True,
+        "compare_with_cmake": False,
+        "strict_cmake_checking": False,
+        "missing_deps_only": False,
+        "ignore_formatting_errors": False,
+    }
+    base.update(overrides)
+    return ValidationConfig(**base)
+
+
+def _parse(xml: str):
+    return ET.fromstring(xml.encode("utf-8"))
+
+
+_PKG_WITH_DEP = """<?xml version="1.0"?>
+<package format="3">
+  <name>demo</name>
+  <exec_depend>rclcpp</exec_depend>
+</package>
+"""
+
+_PKG_NO_DEPS = """<?xml version="1.0"?>
+<package format="3">
+  <name>demo</name>
+</package>
+"""
+
+
+class TestRosdepCheckStepEarlyReturn(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory(prefix="rosdep_check_step_")
+        self.addCleanup(tmp.cleanup)
+        self.fake_xml = os.path.join(tmp.name, "demo", "package.xml")
+
+    def _make_step(self, config: ValidationConfig, rosdep: MagicMock):
+        formatter = PackageXmlFormatter(check_only=config.check_only)
+        return RosdepCheckStep(
+            config=config, formatter=formatter, rosdep_validator=rosdep
+        )
+
+    def test_returns_early_when_check_rosdeps_disabled(self):
+        rosdep = MagicMock()
+        step = self._make_step(_config(check_rosdeps=False), rosdep)
+        result = step.perform_check(_parse(_PKG_WITH_DEP), self.fake_xml)
+
+        self.assertTrue(result.valid)
+        self.assertEqual(result.critical_errors, [])
+        rosdep.check_rosdeps_and_local_pkgs.assert_not_called()
+
+    def test_returns_early_when_missing_deps_only(self):
+        rosdep = MagicMock()
+        step = self._make_step(
+            _config(check_rosdeps=True, missing_deps_only=True), rosdep
+        )
+        result = step.perform_check(_parse(_PKG_WITH_DEP), self.fake_xml)
+
+        self.assertTrue(result.valid)
+        self.assertEqual(result.critical_errors, [])
+        rosdep.check_rosdeps_and_local_pkgs.assert_not_called()
+
+    def test_returns_early_when_no_deps_in_root(self):
+        rosdep = MagicMock()
+        step = self._make_step(_config(check_rosdeps=True), rosdep)
+        result = step.perform_check(_parse(_PKG_NO_DEPS), self.fake_xml)
+
+        self.assertTrue(result.valid)
+        self.assertEqual(result.critical_errors, [])
+        rosdep.check_rosdeps_and_local_pkgs.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_rosdep_mapping.py
+++ b/tests/test_verify_rosdep_mapping.py
@@ -15,10 +15,20 @@ def _install_fake_rosdep(
     *,
     raise_on_init=False,
     rule_for_platform=("apt", {}),
+    raise_resolution_error_on_lookup=False,
 ):
     fake_rosdep2 = ModuleType("rosdep2")
     fake_rospkg_loader = ModuleType("rosdep2.rospkg_loader")
     fake_rospkg_loader.DEFAULT_VIEW_KEY = "default"
+
+    # The production code reads ``rosdep_wrapper.ResolutionError``, which
+    # lazily resolves to ``rosdep2.ResolutionError`` via ``__getattr__``.
+    # The fake module must therefore expose its own class so the
+    # ``except`` block in ``verify_rosdep_mapping`` matches.
+    class FakeResolutionError(Exception):
+        pass
+
+    fake_rosdep2.ResolutionError = FakeResolutionError
 
     class DummyInstallerContext:
         def get_os_name_and_version(self):
@@ -26,6 +36,8 @@ def _install_fake_rosdep(
 
     class DummyDep:
         def get_rule_for_platform(self, os_name, os_version, installers, default):
+            if raise_resolution_error_on_lookup:
+                raise FakeResolutionError("simulated lookup failure")
             return rule_for_platform
 
     class DummyView:
@@ -149,6 +161,45 @@ class TestVerifyRosdepMapping(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as excinfo:
             module.verify_mappings()
+        self.assertEqual(excinfo.exception.code, 1)
+
+    def test_verify_fails_when_yaml_load_raises(self):
+        """``yaml.YAMLError`` during the load step must surface as
+        ``SystemExit(1)`` with a stderr message — covers the
+        ``except (OSError, yaml.YAMLError)`` branch."""
+        repo_root = Path(__file__).resolve().parents[1]
+        os.chdir(repo_root)
+
+        _install_fake_rosdep([])
+        module = _reload_verify_module()
+
+        with patch.object(
+            module.yaml,
+            "safe_load",
+            side_effect=yaml.YAMLError("simulated parse failure"),
+        ):
+            with self.assertRaises(SystemExit) as excinfo:
+                module.verify_mappings()
+        self.assertEqual(excinfo.exception.code, 1)
+
+    def test_verify_reports_resolution_error_per_key(self):
+        """A ``ResolutionError`` from ``get_rule_for_platform`` for a
+        present key must be reported as ``Error looking up`` and cause
+        the run to fail — covers the per-key try/except at
+        ``verify_rosdep_mapping.py:79-85``."""
+        repo_root = Path(__file__).resolve().parents[1]
+        os.chdir(repo_root)
+
+        _install_fake_rosdep(["valid_key"], raise_resolution_error_on_lookup=True)
+        module = _reload_verify_module()
+
+        with patch.object(
+            module.yaml,
+            "safe_load",
+            return_value={"SomeCmakeKey": "valid_key"},
+        ):
+            with self.assertRaises(SystemExit) as excinfo:
+                module.verify_mappings()
         self.assertEqual(excinfo.exception.code, 1)
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -185,6 +185,23 @@ class TestWorkspaceHelpers(unittest.TestCase):
         names = SUT.get_pkgs_in_wrs(self.flat_a / "script.py")
         self.assertEqual(names, ["flat_a", "flat_b"])
 
+    def test_get_pkgs_in_wrs_returns_empty_when_no_pkg_dir_resolvable(self):
+        """Hits the ``pkg_dir is None`` fallback branch: an existing
+        directory with no ``package.xml`` anywhere (up or down) makes
+        ``find_package_dir`` raise, leaving the fallback with nothing to
+        fall back on; the function must return ``[]`` and log a warning.
+        """
+        empty_dir = self.t.root / "empty_no_pkgs"
+        empty_dir.mkdir(parents=True, exist_ok=True)
+
+        with self.assertLogs(SUT.logger, level="WARNING") as captured:
+            names = SUT.get_pkgs_in_wrs(empty_dir)
+
+        self.assertEqual(names, [])
+        self.assertTrue(
+            any("Unable to extract local pkgs" in record for record in captured.output)
+        )
+
     def test_get_pkgs_in_wrs_nonexistent_path_obj_raises_valueerror(self):
         bogus = self.t.root / "does" / "not" / "exist"
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Why

PRs #21 and #22 added significant new code without matching unit tests.
Several logical branches had no test pinning their behaviour — they worked,
but nothing would catch a future refactor that quietly inverts a condition,
drops a warning, or reorders a sort. This PR closes those gaps. The goal is
**regression protection**, not coverage-number theatre.

## What's tested now that wasn't before

### Validation step branches
- `CMakeComparisonStep`: missing `CMakeLists.txt`, strict-vs-non-strict
  unresolved-dep reporting, `evaluate_conditions=False` formatter fallback.
- `RosdepCheckStep`: all three early-return paths.
- `BuildTypeExportStep`: check-only missing/wrong type, no-auto-fill
  critical error, auto-fill success path.
- `PackageXmlValidator`: `compare_with_cmake && !check_rosdeps` guard,
  malformed-XML continuation.

### Parsing & resolution logic
- `cmake_parsers`: `find_package(... QUIET)` without `REQUIRED` is skipped;
  `resolve_for_each` correctly expands `foreach(... IN LISTS ...)` blocks.
- `rosdep_validator.search_rosdep_candidates`: the 4-tier sort order,
  length tiebreaks, and the 5-result cap.

### Filesystem / workspace edge cases
- TOML files outside a `launch/` directory are skipped during launch-dep
  discovery.
- `workspace.get_pkgs_in_wrs` `pkg_dir is None` fallback.
- `verify_rosdep_mapping`: YAML load failure and per-key `ResolutionError`
  paths.
- `resolve_indentation` empty-root / `tail=None` / no-newline fallbacks.

162 → 194 tests, all passing. No production code changes.