### PR TITLE
Add `check-launch-tree`, and scope launch patterns to their format

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,13 +10,18 @@
     pass_filenames: false
     args: [--compare-with-cmake, --auto-fill-missing-deps]
 
-# Report-only, and needs a built and sourced workspace (it resolves through AMENT_PREFIX_PATH,
-# and skips with a message without one). Warns by default so it can be added to a repository
-# that already has findings; pass --error once they are dealt with.
+# Fails on a launch reference no manifest declares; warns about anything only a built
+# workspace could have told it, so a runner without one is not a failure.
+#
+# `verbose: true` is load-bearing: pre-commit discards a passing hook's output, so without it
+# every warning this prints would go nowhere. Pass --warn-only to introduce the hook to a
+# repository that already has findings, and --fatal-under PATH to treat an install space CI
+# fills itself as yours to fix.
 -   id: check-launch-tree
     name: Check launch tree references
-    description: Follow every include from this package's launch files and report references that do not resolve in this workspace.
+    description: Follow every include from this package's launch files, and check that each manifest along the way declares what its launch files name.
     entry: check-launch-tree
     language: python
     pass_filenames: false
-    files: '(launch|launch_manager_components|launch_manager_configs)/.*\.(py|xml|ya?ml)$'
+    verbose: true
+    files: '(^|/)(launch|components|launch_manager_components|launch_manager_configs)/.*\.(py|xml|ya?ml|toml|launch)$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,3 +9,14 @@
     language: python
     pass_filenames: false
     args: [--compare-with-cmake, --auto-fill-missing-deps]
+
+# Report-only, and needs a built and sourced workspace (it resolves through AMENT_PREFIX_PATH,
+# and skips with a message without one). Warns by default so it can be added to a repository
+# that already has findings; pass --error once they are dealt with.
+-   id: check-launch-tree
+    name: Check launch tree references
+    description: Follow every include from this package's launch files and report references that do not resolve in this workspace.
+    entry: check-launch-tree
+    language: python
+    pass_filenames: false
+    files: '(launch|launch_manager_components|launch_manager_configs)/.*\.(py|xml|ya?ml)$'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ repos:
     hooks:
       - id: format-package-xml
         name: Format package.xml
+      # Optional. Warns only; add args: [--error] to make findings fatal.
+      - id: check-launch-tree
+        name: Check launch tree references
 ```
 
 ### 2. Install the Hook
@@ -132,6 +135,12 @@ The on-disk file now matches the **After** snippet above. The exit code is non-z
 * **Launch File Scanning:** Scans `.py`, `.yaml`, and `.xml` launch files. If a package is used in a launch file but missing from `package.xml`, it adds it as an `<exec_depend>` or `<test_depend>`. Can be disabled with `--skip-launch-dep-check` when launch scanning produces false positives or is not desired for a given package.
 * **CMake Synchronization:** Compares `package.xml` against `CMakeLists.txt` to ensure build dependencies match, adding missing entries as `<depend>` or `<test_depend>`. Calls of the form `find_package(<pkg> QUIET)` are treated as optional and skipped. all other forms such as `find_package(<pkg>)`, `find_package(<pkg> REQUIRED)`, and `find_package(<pkg> REQUIRED QUIET)` are enforced in `package.xml`.
 * **Rosdep Validation:** Verifies that your dependency names exist as valid keys in the rosdep database.
+
+### Launch Tree Integrity
+
+The separate `check-launch-tree` hook follows every include out of a package's launch files, across package boundaries, and reports references that do not resolve: a package that is not installed, and an include whose package is present but whose launch file is not. Includes it cannot follow — a name built from `$(eval …)`, or an argument with no value — are listed as unchecked rather than assumed fine.
+
+Report-only, since neither finding is fixable by editing a manifest. It resolves packages through `AMENT_PREFIX_PATH`, so it needs a built and sourced workspace and skips with a message without one. Pass `--arg NAME=VALUE` to follow the tree a particular set of launch arguments produces, and `--error` to exit non-zero on findings.
 
 ### Build Configuration
 
@@ -246,6 +255,7 @@ against the in-memory tree, and writes back only if a step actually mutated.
 | Module | Responsibility |
 | --- | --- |
 | `package_xml_validator.py` | CLI entry point and per-file orchestration (parse → run steps → optionally write). |
+| `check_launch_tree.py` | Second entry point: follows the launch tree across packages and reports references that do not resolve. |
 | `helpers/validation_steps/` | One `*Step` class per validation rule. Each docstring states the rule, inputs, and when (if ever) it mutates the tree. |
 | `helpers/formatter/` | Pure structural checks (`structural_checks.py`), tree mutators (`mutations.py`), indentation/pretty-print helpers, and shared schema constants. `PackageXmlFormatter` is a thin facade. |
 | `helpers/cmake_parsers.py` | Lightweight regex-based CMake parser used by `CMakeComparisonStep`. |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: format-package-xml
         name: Format package.xml
-      # Optional. Warns only; add args: [--error] to make findings fatal.
+      # Optional. See "Launch Tree Integrity" below.
       - id: check-launch-tree
         name: Check launch tree references
 ```
@@ -138,9 +138,27 @@ The on-disk file now matches the **After** snippet above. The exit code is non-z
 
 ### Launch Tree Integrity
 
-The separate `check-launch-tree` hook follows every include out of a package's launch files, across package boundaries, and reports references that do not resolve: a package that is not installed, and an include whose package is present but whose launch file is not. Includes it cannot follow, e.g. a name built from `$(eval …)`, or an argument with no value, are listed as unchecked rather than assumed fine.
+The separate `check-launch-tree` hook follows every include out of a package's launch files, across package boundaries, and grades what it finds by whether anyone can act on it:
 
-Report-only, since neither finding is fixable by editing a manifest. It resolves packages through `AMENT_PREFIX_PATH`, so it needs a built and sourced workspace and skips with a message without one. Pass `--arg NAME=VALUE` to follow the tree a particular set of launch arguments produces, and `--error` to exit non-zero on findings.
+| Finding | Meaning | Effect |
+| --- | --- | --- |
+| not declared | a launch file names a package its own `package.xml` does not depend on | **fails the run** |
+| dead include | the package is installed, the launch file it names is not | **fails the run** |
+| not installed | nothing in this workspace provides the package | warning |
+| could not be followed | a name built from `$(eval …)`, or an argument with no value | warning |
+
+The split is what makes the hook usable in CI: a runner that has not built the workspace will report half of it as not installed, which is nobody's fault, while a missing manifest entry is a real defect and needs no workspace to see.
+
+The two fatal findings only fail the run when the package that *owns* the offending launch file is one you can fix — a package in the checkout being scanned, or one below a `--fatal-under` prefix. Against a binary-only install they drop to warnings. Where a package is both installed and in the checkout, the checkout's manifest is the one checked.
+
+Crossing package boundaries resolves through `AMENT_PREFIX_PATH`. Without a sourced workspace the walk stops at the checkout's own launch files and says so; the manifest check still runs.
+
+| Option | |
+| --- | --- |
+| `--fatal-under PATH` | also treat packages installed below `PATH` as yours to fix. Repeatable. In CI, `--fatal-under /opt/<distro>` covers packages the pipeline installs itself |
+| `--warn-only` | report everything, always exit zero — for introducing the hook to a repository that already has findings |
+| `--ignore NAME` | leave a package out of every report. Repeatable |
+| `--arg NAME=VALUE` | follow the tree a particular set of launch arguments produces, rather than the one the declared defaults describe. Repeatable |
 
 ### Build Configuration
 
@@ -255,7 +273,7 @@ against the in-memory tree, and writes back only if a step actually mutated.
 | Module | Responsibility |
 | --- | --- |
 | `package_xml_validator.py` | CLI entry point and per-file orchestration (parse → run steps → optionally write). |
-| `check_launch_tree.py` | Second entry point: follows the launch tree across packages and reports references that do not resolve. |
+| `check_launch_tree.py` | Second entry point: follows the launch tree across packages, and grades each finding by whether the package that owns the offending file is one the committer can fix. |
 | `helpers/validation_steps/` | One `*Step` class per validation rule. Each docstring states the rule, inputs, and when (if ever) it mutates the tree. |
 | `helpers/formatter/` | Pure structural checks (`structural_checks.py`), tree mutators (`mutations.py`), indentation/pretty-print helpers, and shared schema constants. `PackageXmlFormatter` is a thin facade. |
 | `helpers/cmake_parsers.py` | Lightweight regex-based CMake parser used by `CMakeComparisonStep`. |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The on-disk file now matches the **After** snippet above. The exit code is non-z
 
 ### Launch Tree Integrity
 
-The separate `check-launch-tree` hook follows every include out of a package's launch files, across package boundaries, and reports references that do not resolve: a package that is not installed, and an include whose package is present but whose launch file is not. Includes it cannot follow — a name built from `$(eval …)`, or an argument with no value — are listed as unchecked rather than assumed fine.
+The separate `check-launch-tree` hook follows every include out of a package's launch files, across package boundaries, and reports references that do not resolve: a package that is not installed, and an include whose package is present but whose launch file is not. Includes it cannot follow, e.g. a name built from `$(eval …)`, or an argument with no value, are listed as unchecked rather than assumed fine.
 
 Report-only, since neither finding is fixable by editing a manifest. It resolves packages through `AMENT_PREFIX_PATH`, so it needs a built and sourced workspace and skips with a message without one. Pass `--arg NAME=VALUE` to follow the tree a particular set of launch arguments produces, and `--error` to exit non-zero on findings.
 

--- a/README.md
+++ b/README.md
@@ -147,15 +147,21 @@ The separate `check-launch-tree` hook follows every include out of a package's l
 | not installed | nothing in this workspace provides the package | warning |
 | could not be followed | a name built from `$(eval …)`, or an argument with no value | warning |
 
-The split is what makes the hook usable in CI: a runner that has not built the workspace will report half of it as not installed, which is nobody's fault, while a missing manifest entry is a real defect and needs no workspace to see.
+The two fatal findings only fail the run when the package that *owns* the offending launch file is one you can fix. Three things count:
 
-The two fatal findings only fail the run when the package that *owns* the offending launch file is one you can fix — a package in the checkout being scanned, or one below a `--fatal-under` prefix. Against a binary-only install they drop to warnings. Where a package is both installed and in the checkout, the checkout's manifest is the one checked.
+1. it is in the repository being scanned;
+2. its source is elsewhere in the same workspace's `src`, found by walking up to the workspace root — the usual ROS layout is one repository per package, so a defect one include away is normally in a sibling repository rather than in this one;
+3. it is below a `--fatal-under` prefix, which is how CI marks an install space the pipeline populates itself.
+
+Anything else — a package that exists only as a binary install — drops to a warning, since no commit here can fix it.
+
+Where a package appears in more than one of those places, the most editable copy wins: the manifest reported and graded is the one in the repository, then the one in the workspace, then the installed one. This matters because includes resolve through `find-pkg-share`, so the launch file the walk actually *reads* is almost always the installed copy.
 
 Crossing package boundaries resolves through `AMENT_PREFIX_PATH`. Without a sourced workspace the walk stops at the checkout's own launch files and says so; the manifest check still runs.
 
 | Option | |
 | --- | --- |
-| `--fatal-under PATH` | also treat packages installed below `PATH` as yours to fix. Repeatable. In CI, `--fatal-under /opt/<distro>` covers packages the pipeline installs itself |
+| `--fatal-under PATH` | also treat packages below `PATH` as yours to fix. Repeatable. In CI, `--fatal-under /opt/<distro>` covers packages the pipeline installs itself. The repository and the surrounding workspace already count without it |
 | `--warn-only` | report everything, always exit zero — for introducing the hook to a repository that already has findings |
 | `--ignore NAME` | leave a package out of every report. Repeatable |
 | `--arg NAME=VALUE` | follow the tree a particular set of launch arguments produces, rather than the one the declared defaults describe. Repeatable |

--- a/README.md
+++ b/README.md
@@ -150,12 +150,8 @@ The separate `check-launch-tree` hook follows every include out of a package's l
 The two fatal findings only fail the run when the package that *owns* the offending launch file is one you can fix. Three things count:
 
 1. it is in the repository being scanned;
-2. its source is elsewhere in the same workspace's `src`, found by walking up to the workspace root — the usual ROS layout is one repository per package, so a defect one include away is normally in a sibling repository rather than in this one;
+2. its source is elsewhere in the same workspace's `src`,
 3. it is below a `--fatal-under` prefix, which is how CI marks an install space the pipeline populates itself.
-
-Anything else — a package that exists only as a binary install — drops to a warning, since no commit here can fix it.
-
-Where a package appears in more than one of those places, the most editable copy wins: the manifest reported and graded is the one in the repository, then the one in the workspace, then the installed one. This matters because includes resolve through `find-pkg-share`, so the launch file the walk actually *reads* is almost always the installed copy.
 
 Crossing package boundaries resolves through `AMENT_PREFIX_PATH`. Without a sourced workspace the walk stops at the checkout's own launch files and says so; the manifest check still runs.
 

--- a/package_xml_validation/check_launch_tree.py
+++ b/package_xml_validation/check_launch_tree.py
@@ -14,15 +14,17 @@ what it finds by whether anyone can act on it:
 * **an include nobody could follow** - a warning, listed so a walk that read half the tree does
   not read like one that read all of it.
 
-The two fatal kinds only fail the run when the *owning* package is one the committer can fix:
-a package in the checkout being scanned, or one under a `--fatal-under` prefix. Against a
-binary-only install they are reported as warnings.
+The two fatal kinds only fail the run when the *owning* package is one the committer can fix,
+which is any of three things: a package in the checkout being scanned, one whose source is
+elsewhere in the same workspace's `src`, or one below a `--fatal-under` prefix. Against a
+package that is only a binary install they are reported as warnings.
 
 Crossing package boundaries needs `AMENT_PREFIX_PATH`. Without it the walk stops at the
 checkout's own launch files and says so - the manifest check still runs, since it never needed
 a workspace.
 """
 
+from pathlib import Path
 from typing import NamedTuple, Optional
 import argparse
 import os
@@ -42,7 +44,7 @@ from .helpers.formatter.dependency_queries import (
     get_package_name,
     retrieve_exec_dependencies_with_conditions,
 )
-from .helpers.workspace import find_package_xml_files
+from .helpers.workspace import find_package_xml_files, find_workspace_root
 
 __all__ = [
     "FATAL",
@@ -92,14 +94,36 @@ class Finding(NamedTuple):
     """For a dead include, the file the include named."""
 
 
+def workspace_sources(paths: "list[str]") -> "list[str]":
+    """The `<ws>/src` each path sits in, where there is one.
+
+    A package is fixable when its source is anywhere in the same workspace, not only when it
+    is in the repository being committed to - a workspace with one repository per package
+    would otherwise put every sibling out of reach.
+    """
+    found: "list[str]" = []
+    for one in paths:
+        try:
+            # Resolved first: find_workspace_root compares the path it is handed against an
+            # absolute <ws>/src, and the hook passes `.`.
+            root = find_workspace_root(Path(one).resolve())
+        except ValueError:
+            # Not a <ws>/src/<pkg> layout, so there is no workspace tier. Not a problem.
+            continue
+        source = root / "src"
+        if source.is_dir() and str(source) not in found:
+            found.append(str(source))
+    return found
+
+
 class Scope(NamedTuple):
     """Which manifests this run may fail on, and which names never to report at all."""
 
     source: dict
-    """`package name -> package.xml` for the checkout being scanned. Always ours to fix."""
+    """`package name -> package.xml`, for every package this run is allowed to fail on."""
 
     fatal_under: tuple = ()
-    """Extra prefixes to treat the same way, such as an install space CI fills itself."""
+    """The `--fatal-under` prefixes, kept so a manifest the index missed is still covered."""
 
     ignored: frozenset = frozenset()
 
@@ -110,7 +134,17 @@ class Scope(NamedTuple):
         fatal_under: "tuple[str, ...]" = (),
         ignored: "frozenset[str]" = frozenset(),
     ) -> "Scope":
-        return cls(_index(find_package_xml_files(paths)), fatal_under, ignored)
+        """Index every package a finding may be fatal against.
+
+        Three tiers: a listed path, such as an install space CI populates itself; the `src` of
+        the surrounding workspace; and the checkout being scanned. Indexed least editable
+        first, so where a package appears in more than one the most editable copy wins - that
+        is both the manifest a finding is reported against and the one it is graded on.
+        """
+        index: dict = {}
+        for root in (*fatal_under, *workspace_sources(paths), *paths):
+            index.update(_index(find_package_xml_files([root])))
+        return cls(index, fatal_under, ignored)
 
     def severity_of(self, manifest: Optional[str]) -> str:
         if manifest is None:
@@ -434,8 +468,9 @@ def main() -> None:
         action="append",
         default=[],
         metavar="PATH",
-        help="Also treat packages installed below PATH as yours to fix, so findings against "
-        "them fail the run. Repeat for several. Packages in SRC always count.",
+        help="Also treat packages below PATH as yours to fix, so findings against them fail "
+        "the run. Repeat for several. Packages in SRC, and packages whose source is elsewhere "
+        "in the same workspace, already count without this.",
     )
     parser.add_argument(
         "--ignore",
@@ -471,9 +506,7 @@ def main() -> None:
         print("check-launch-tree: no packages found. Nothing to check.")
         return
 
-    scope = Scope(
-        _index(manifests), tuple(parsed.fatal_under), frozenset(parsed.ignore)
-    )
+    scope = Scope.of(parsed.src, tuple(parsed.fatal_under), frozenset(parsed.ignore))
     resolvable = workspace_is_available()
 
     fatal = 0

--- a/package_xml_validation/check_launch_tree.py
+++ b/package_xml_validation/check_launch_tree.py
@@ -1,40 +1,128 @@
 #!/usr/bin/env python3
-"""Does everything this launch tree reaches actually exist here?
+"""Does everything this launch tree reaches exist, and does every manifest admit to it?
 
-Follows every include from a package's launch files, across package boundaries, and reports
-two kinds of finding:
+Follows every include out of a package's launch files, across package boundaries, and grades
+what it finds by whether anyone can act on it:
 
-* **a package that is not installed** - the launch file names it, nothing here provides it;
-* **an include that leads nowhere** - the package is there, the launch file it names is not.
+* **a reference no manifest declares** - a launch file names a package that its own
+  `package.xml` does not depend on. A defect in the checkout, visible without a workspace,
+  so it fails the run.
+* **an include that leads nowhere** - the package is installed, the launch file it names is
+  not. Also a defect, and also fatal.
+* **a package that is not installed here** - a warning. A CI runner may simply not have built
+  it, and nothing in the checkout is wrong.
+* **an include nobody could follow** - a warning, listed so a walk that read half the tree does
+  not read like one that read all of it.
 
-Neither is fixable by editing a manifest, so this is a separate entry point from
-`package_xml_validator` rather than a flag on it: it only reports, and it resolves through
-`AMENT_PREFIX_PATH`, so it needs a built and sourced workspace. Without one it says so and
-skips, rather than reporting every package as missing.
+The two fatal kinds only fail the run when the *owning* package is one the committer can fix:
+a package in the checkout being scanned, or one under a `--fatal-under` prefix. Against a
+binary-only install they are reported as warnings.
+
+Crossing package boundaries needs `AMENT_PREFIX_PATH`. Without it the walk stops at the
+checkout's own launch files and says so - the manifest check still runs, since it never needed
+a workspace.
 """
 
-from typing import Optional
+from typing import NamedTuple, Optional
 import argparse
 import os
 import sys
 
+import lxml.etree as ET
+
+from .helpers.condition_eval import evaluate_condition
+from .helpers.exception_parser import parse_exceptions
 from .helpers.find_launch_dependencies import (
     Walk,
     default_share_lookup,
     is_literal_package,
     scan_directories,
 )
+from .helpers.formatter.dependency_queries import (
+    get_package_name,
+    retrieve_exec_dependencies_with_conditions,
+)
 from .helpers.workspace import find_package_xml_files
 
-__all__ = ["check", "main", "package_dirs_under"]
+__all__ = [
+    "FATAL",
+    "WARNING",
+    "Finding",
+    "Scope",
+    "check",
+    "main",
+    "package_dirs_under",
+]
 
 
-#: Directories worth seeding from: `launch`, plus the two that hold launch-manager component
-#: definitions naming the package and launch file they start.
-DEFAULT_SEED_DIRS = ("launch", "launch_manager_components", "launch_manager_configs")
+#: Directories worth seeding from: `launch` and `components` as the manifest validator uses
+#: them, plus the two that hold launch-manager component definitions.
+DEFAULT_SEED_DIRS = (
+    "launch",
+    "components",
+    "launch_manager_components",
+    "launch_manager_configs",
+)
 
 #: How many unfollowable includes to list before summarising the rest as a count.
 LISTED_UNREAD = 5
+
+FATAL = "error"
+WARNING = "warning"
+
+UNDECLARED = "undeclared"
+DEAD_INCLUDE = "dead-include"
+NOT_INSTALLED = "not-installed"
+
+
+class Finding(NamedTuple):
+    """One thing worth saying about a launch tree."""
+
+    kind: str
+    severity: str
+    package: str
+    file: str
+    """The launch file the reference was written in."""
+
+    line: int
+    owner: Optional[str] = None
+    """The `package.xml` held responsible, where there is one."""
+
+    launch_file: str = ""
+    """For a dead include, the file the include named."""
+
+
+class Scope(NamedTuple):
+    """Which manifests this run may fail on, and which names never to report at all."""
+
+    source: dict
+    """`package name -> package.xml` for the checkout being scanned. Always ours to fix."""
+
+    fatal_under: tuple = ()
+    """Extra prefixes to treat the same way, such as an install space CI fills itself."""
+
+    ignored: frozenset = frozenset()
+
+    @classmethod
+    def of(
+        cls,
+        paths: "list[str]",
+        fatal_under: "tuple[str, ...]" = (),
+        ignored: "frozenset[str]" = frozenset(),
+    ) -> "Scope":
+        return cls(_index(find_package_xml_files(paths)), fatal_under, ignored)
+
+    def severity_of(self, manifest: Optional[str]) -> str:
+        if manifest is None:
+            return WARNING
+        if manifest in self.source.values():
+            return FATAL
+        absolute = os.path.abspath(manifest)
+        under = any(
+            absolute.startswith(os.path.abspath(one) + os.sep)
+            for one in self.fatal_under
+        )
+        return FATAL if under else WARNING
 
 
 def workspace_is_available() -> bool:
@@ -42,10 +130,6 @@ def workspace_is_available() -> bool:
     return any(
         part for part in os.environ.get("AMENT_PREFIX_PATH", "").split(os.pathsep)
     )
-
-
-def _installed(package: str) -> bool:
-    return default_share_lookup(package) is not None
 
 
 def package_dirs_under(paths: "list[str]") -> "list[str]":
@@ -58,12 +142,23 @@ def package_dirs_under(paths: "list[str]") -> "list[str]":
     return sorted({os.path.dirname(one) for one in find_package_xml_files(paths)})
 
 
-def check(package_dir: str, args: Optional[dict] = None) -> "tuple[Walk, list, list]":
-    """Follow one package's launch tree.
+def check(
+    package_dir: str,
+    args: Optional[dict] = None,
+    scope: Optional[Scope] = None,
+    resolvable: Optional[bool] = None,
+) -> "tuple[Walk, list[Finding]]":
+    """Follow one package's launch tree and grade what it finds.
 
     `package_dir` is a single package directory, not a repository root - see
-    :py:func:`package_dirs_under`. Returns `(walk, missing packages, dead includes)`.
+    :py:func:`package_dirs_under`. `scope` decides which findings are fatal, and defaults to
+    treating this package alone as the checkout.
     """
+    if scope is None:
+        scope = Scope.of([package_dir])
+    if resolvable is None:
+        resolvable = workspace_is_available()
+
     seeds = [
         os.path.join(package_dir, name)
         for name in DEFAULT_SEED_DIRS
@@ -74,20 +169,184 @@ def check(package_dir: str, args: Optional[dict] = None) -> "tuple[Walk, list, l
     # reported - once.
     walk = scan_directories(seeds, args=args)
 
-    missing = sorted(
-        {one.package for one in walk.references if not _installed(one.package)}
+    return walk, _findings(walk, scope, resolvable)
+
+
+# ── Reading the manifests a walk is graded against ───────────────────────────────────────
+
+_MANIFESTS: "dict[str, tuple[Optional[str], frozenset, frozenset]]" = {}
+
+
+def _read(manifest: str) -> "tuple[Optional[str], frozenset, frozenset]":
+    """`(package name, declared exec deps, names to ignore)`, parsed once per path.
+
+    Exec dependencies, because a launch file names what it runs. Conditions are evaluated and
+    `<!-- validator:ignore ... -->` is honoured, so this agrees with what
+    `package-xml-validator` would say about the same manifest.
+    """
+    if manifest not in _MANIFESTS:
+        try:
+            parser = ET.XMLParser(no_network=True, resolve_entities=False)
+            root = ET.parse(manifest, parser).getroot()
+        except (OSError, ET.XMLSyntaxError):
+            _MANIFESTS[manifest] = (None, frozenset(), frozenset())
+        else:
+            declared = frozenset(
+                name
+                for name, condition in retrieve_exec_dependencies_with_conditions(root)
+                if evaluate_condition(condition)
+            )
+            _MANIFESTS[manifest] = (
+                get_package_name(root),
+                declared,
+                parse_exceptions(root).ignored_deps,
+            )
+    return _MANIFESTS[manifest]
+
+
+def _index(manifests: "list[str]") -> dict:
+    """`package name -> package.xml`, for looking a source manifest up by name."""
+    found = {}
+    for manifest in manifests:
+        name = _read(manifest)[0]
+        if name:
+            found[name] = manifest
+    return found
+
+
+def _owner(path: str, source: dict) -> Optional[str]:
+    """The `package.xml` responsible for `path`, preferring the checkout to an installed copy.
+
+    Includes resolve through `find-pkg-share`, so most files a walk reads are installed copies.
+    Where the same package is also in the checkout, that is the manifest a committer can edit
+    and the one the run should be graded against.
+    """
+    directory = os.path.dirname(os.path.abspath(path))
+    while True:
+        manifest = os.path.join(directory, "package.xml")
+        if os.path.isfile(manifest):
+            name = _read(manifest)[0]
+            return source.get(name, manifest) if name else manifest
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            return None
+        directory = parent
+
+
+# ── Grading a walk ───────────────────────────────────────────────────────────────────────
+
+
+def _findings(walk: Walk, scope: Scope, resolvable: bool) -> "list[Finding]":
+    owners = {one: _owner(one, scope.source) for one in walk.visited}
+
+    # Absent as far as the walk is concerned. An include into one of these could not be
+    # followed, so calling it a package that fails to ship a file would be a guess.
+    absent = (
+        {one for one in walk.packages if default_share_lookup(one) is None}
+        if resolvable
+        else set()
     )
 
-    # A dead include is one whose package is here and whose file is not. An include whose
-    # package is absent is already reported as missing, and one whose name still holds a
-    # substitution names no package at all - both belong in the unfollowable list instead.
-    dead = [
-        one
+    findings: list[Finding] = []
+    findings.extend(_undeclared(walk, scope, owners))
+    if resolvable:
+        findings.extend(_dead(walk, scope, owners, absent))
+        findings.extend(_absent(walk, scope, owners, absent))
+
+    return sorted(
+        findings, key=lambda one: (one.severity != FATAL, one.kind, one.package)
+    )
+
+
+def _muted(package: str, scope: Scope, manifest: Optional[str]) -> bool:
+    """Whether this package was asked to be left out, globally or by the manifest citing it."""
+    if package in scope.ignored:
+        return True
+    return manifest is not None and package in _read(manifest)[2]
+
+
+def _first_mention(walk: Walk) -> dict:
+    """Where each package was first named, so a finding can cite one place rather than all."""
+    where: dict = {}
+    for one in walk.references:
+        where.setdefault(one.package, one)
+    return where
+
+
+def _undeclared(walk: Walk, scope: Scope, owners: dict) -> "list[Finding]":
+    """References a launch file makes that its own package.xml does not declare."""
+    findings = []
+    seen = set()
+
+    for one in walk.references:
+        manifest = owners.get(one.file)
+        if manifest is None or _muted(one.package, scope, manifest):
+            continue
+
+        name, declared, _ = _read(manifest)
+        if one.package == name or one.package in declared:
+            continue
+
+        if (manifest, one.package) in seen:
+            continue
+        seen.add((manifest, one.package))
+
+        findings.append(
+            Finding(
+                UNDECLARED,
+                scope.severity_of(manifest),
+                one.package,
+                one.file,
+                one.line,
+                manifest,
+            )
+        )
+
+    return findings
+
+
+def _dead(walk: Walk, scope: Scope, owners: dict, absent: set) -> "list[Finding]":
+    """Includes whose package is here and whose file is not.
+
+    An include into a package that is not here at all could not be followed for a different
+    reason, and one whose name still holds a substitution names no package at all - neither is
+    evidence that a file is missing.
+    """
+    return [
+        Finding(
+            DEAD_INCLUDE,
+            scope.severity_of(owners.get(one.file)),
+            one.package,
+            one.file,
+            one.line,
+            owners.get(one.file),
+            one.launch_file,
+        )
         for one in walk.unresolved
-        if is_literal_package(one.package) and one.package not in missing
+        if is_literal_package(one.package)
+        and one.package not in absent
+        and not _muted(one.package, scope, owners.get(one.file))
     ]
 
-    return walk, missing, dead
+
+def _absent(walk: Walk, scope: Scope, owners: dict, absent: set) -> "list[Finding]":
+    """Packages nothing in this workspace provides.
+
+    A package that is in the checkout is left out: it is not missing, only unbuilt, which is
+    the ordinary state of a CI runner and says nothing about the tree.
+    """
+    return [
+        Finding(
+            NOT_INSTALLED, WARNING, package, one.file, one.line, owners.get(one.file)
+        )
+        for package, one in _first_mention(walk).items()
+        if package in absent
+        and package not in scope.source
+        and not _muted(package, scope, owners.get(one.file))
+    ]
+
+
+# ── Saying it ────────────────────────────────────────────────────────────────────────────
 
 
 def _where(path: str, package_dir: str) -> str:
@@ -100,47 +359,69 @@ def _where(path: str, package_dir: str) -> str:
     return os.path.abspath(path) if relative.startswith("..") else relative
 
 
-def _report(package_dir: str, walk: Walk, missing: list, dead: list) -> None:
+def _report(
+    package_dir: str, walk: Walk, findings: "list[Finding]", resolvable: bool
+) -> None:
+    """Print what this package's tree turned up, or nothing at all if it turned up nothing."""
+    unread = _unfollowable(walk, findings)
+    if not findings and not unread:
+        return
+
     name = os.path.basename(os.path.abspath(package_dir))
     print(
         f"{name}: read {len(walk.visited)} launch file(s), {len(walk.packages)} package(s)"
     )
 
-    where: dict = {}
-    for one in walk.references:
-        where.setdefault(one.package, one)
+    # A package that is both undeclared and absent is one problem, so the absence is a clause
+    # on the manifest finding rather than a second line under it.
+    uninstalled = {one.package for one in findings if one.kind == NOT_INSTALLED}
+    also_undeclared = {one.package for one in findings if one.kind == UNDECLARED}
 
-    for package in missing:
-        cited = where.get(package)
-        print(f"  {package} is not installed in this workspace")
-        if cited:
-            print(f"      referenced by {_where(cited.file, package_dir)}:{cited.line}")
+    for one in findings:
+        if one.kind == NOT_INSTALLED and one.package in also_undeclared:
+            continue
+        print(f"  {one.severity:<7} {_message(one, package_dir, uninstalled)}")
+        print(f"          referenced by {_where(one.file, package_dir)}:{one.line}")
 
-    for edge in dead:
-        print(f"  {edge.package} does not ship {edge.launch_file}")
-        print(f"      referenced by {_where(edge.file, package_dir)}:{edge.line}")
-
-    # Edges the two sections above have not already accounted for.
-    explained = set(missing)
-    unread = [
-        one
-        for one in walk.unresolved
-        if one not in dead and one.package not in explained
-    ]
     if unread:
-        # Printed even when nothing is wrong, so a clean result that skipped half the tree
-        # does not read like one that did not.
-        print(f"  {len(unread)} include(s) could not be followed and were not checked:")
+        print(f"  {WARNING:<7} {len(unread)} include(s) could not be followed:")
         for edge in unread[:LISTED_UNREAD]:
             target = f"{edge.package or '(computed)'}/{edge.launch_file}"
-            print(f"      {_where(edge.file, package_dir)}:{edge.line}  {target}")
+            print(f"          {_where(edge.file, package_dir)}:{edge.line}  {target}")
         if len(unread) > LISTED_UNREAD:
-            print(f"      ... and {len(unread) - LISTED_UNREAD} more")
+            print(f"          ... and {len(unread) - LISTED_UNREAD} more")
+
+    if not resolvable:
+        print(
+            f"  {WARNING:<7} AMENT_PREFIX_PATH is empty, so includes into other packages were "
+            "not followed."
+        )
+
+
+def _message(one: Finding, package_dir: str, uninstalled: set) -> str:
+    if one.kind == NOT_INSTALLED:
+        return f"{one.package} is not installed in this workspace"
+
+    if one.kind == DEAD_INCLUDE:
+        return f"{one.package} does not ship {one.launch_file}"
+
+    owner = _where(one.owner, package_dir) if one.owner else "its package.xml"
+    absent = " (and is not installed here)" if one.package in uninstalled else ""
+    return f"{one.package} is not declared in {owner}{absent}"
+
+
+def _unfollowable(walk: Walk, findings: "list[Finding]") -> list:
+    """Includes no finding above has already accounted for."""
+    explained = {
+        one.package for one in findings if one.kind in (DEAD_INCLUDE, NOT_INSTALLED)
+    }
+    return [one for one in walk.unresolved if one.package not in explained]
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Check that everything a package's launch tree references exists here."
+        description="Check that everything a package's launch tree references exists here, "
+        "and that every manifest along the way declares what its launch files name."
     )
     parser.add_argument(
         "src",
@@ -149,10 +430,25 @@ def main() -> None:
         help="Files or directories to search for packages. Defaults to the current directory.",
     )
     parser.add_argument(
-        "--error",
+        "--fatal-under",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Also treat packages installed below PATH as yours to fix, so findings against "
+        "them fail the run. Repeat for several. Packages in SRC always count.",
+    )
+    parser.add_argument(
+        "--ignore",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="A package to leave out of every report. Repeat for several.",
+    )
+    parser.add_argument(
+        "--warn-only",
         action="store_true",
-        help="Exit non-zero on findings. Warns only by default, so it can be introduced to a "
-        "repository that already has some.",
+        help="Report everything but always exit zero, for introducing the check to a "
+        "repository that already has findings.",
     )
     parser.add_argument(
         "--arg",
@@ -164,32 +460,29 @@ def main() -> None:
     )
     parsed = parser.parse_args()
 
-    if not workspace_is_available():
-        # Not a failure: with nothing to resolve against, every package would read as missing.
-        print(
-            "check-launch-tree: AMENT_PREFIX_PATH is empty, so packages cannot be resolved - "
-            "the launch tree was not checked. Source the workspace to enable this check."
-        )
-        return
-
     args = {}
     for item in parsed.arg:
         name, _, value = item.partition("=")
         if name:
             args[name] = value
 
-    package_dirs = package_dirs_under(parsed.src)
-    if not package_dirs:
+    manifests = find_package_xml_files(parsed.src)
+    if not manifests:
         print("check-launch-tree: no packages found. Nothing to check.")
         return
 
-    findings = 0
-    for package_dir in package_dirs:
-        walk, missing, dead = check(package_dir, args or None)
-        _report(package_dir, walk, missing, dead)
-        findings += len(missing) + len(dead)
+    scope = Scope(
+        _index(manifests), tuple(parsed.fatal_under), frozenset(parsed.ignore)
+    )
+    resolvable = workspace_is_available()
 
-    if findings and parsed.error:
+    fatal = 0
+    for package_dir in sorted({os.path.dirname(one) for one in manifests}):
+        walk, findings = check(package_dir, args or None, scope, resolvable)
+        _report(package_dir, walk, findings, resolvable)
+        fatal += sum(1 for one in findings if one.severity == FATAL)
+
+    if fatal and not parsed.warn_only:
         sys.exit(1)
 
 

--- a/package_xml_validation/check_launch_tree.py
+++ b/package_xml_validation/check_launch_tree.py
@@ -18,9 +18,14 @@ import argparse
 import os
 import sys
 
-from .helpers.find_launch_dependencies import Walk, scan_directory
+from .helpers.find_launch_dependencies import (
+    Walk,
+    default_share_lookup,
+    scan_directory,
+)
+from .helpers.workspace import find_package_xml_files
 
-__all__ = ["check", "main"]
+__all__ = ["check", "main", "package_dirs_under"]
 
 
 #: Directories worth seeding from: `launch`, plus the two that hold launch-manager component
@@ -36,13 +41,25 @@ def workspace_is_available() -> bool:
 
 
 def _installed(package: str) -> bool:
-    from .helpers.find_launch_dependencies import default_share_lookup
-
     return default_share_lookup(package) is not None
 
 
+def package_dirs_under(paths: "list[str]") -> "list[str]":
+    """The directories holding a `package.xml`, at any depth below `paths`.
+
+    `check` works on one package at a time, but the hook is given a repository root. Reusing
+    the validator's discovery means both entry points agree on what a package is, and on which
+    directories (`COLCON_IGNORE` and friends) are skipped.
+    """
+    return sorted({os.path.dirname(one) for one in find_package_xml_files(paths)})
+
+
 def check(package_dir: str, args: Optional[dict] = None) -> "tuple[Walk, list, list]":
-    """Follow this package's launch tree. Returns `(walk, missing packages, dead includes)`."""
+    """Follow one package's launch tree.
+
+    `package_dir` is a single package directory, not a repository root - see
+    :py:func:`package_dirs_under`. Returns `(walk, missing packages, dead includes)`.
+    """
     seeds = [
         os.path.join(package_dir, name)
         for name in DEFAULT_SEED_DIRS
@@ -128,7 +145,10 @@ def main() -> None:
         description="Check that everything a package's launch tree references exists here."
     )
     parser.add_argument(
-        "src", nargs="*", default=["."], help="Package directories to check."
+        "src",
+        nargs="*",
+        default=["."],
+        help="Files or directories to search for packages. Defaults to the current directory.",
     )
     parser.add_argument(
         "--error",
@@ -160,8 +180,13 @@ def main() -> None:
         if name:
             args[name] = value
 
+    package_dirs = package_dirs_under(parsed.src)
+    if not package_dirs:
+        print("check-launch-tree: no packages found. Nothing to check.")
+        return
+
     findings = 0
-    for package_dir in parsed.src or ["."]:
+    for package_dir in package_dirs:
         walk, missing, dead = check(package_dir, args or None)
         _report(package_dir, walk, missing, dead)
         findings += len(missing) + len(dead)

--- a/package_xml_validation/check_launch_tree.py
+++ b/package_xml_validation/check_launch_tree.py
@@ -21,7 +21,8 @@ import sys
 from .helpers.find_launch_dependencies import (
     Walk,
     default_share_lookup,
-    scan_directory,
+    is_literal_package,
+    scan_directories,
 )
 from .helpers.workspace import find_package_xml_files
 
@@ -31,6 +32,9 @@ __all__ = ["check", "main", "package_dirs_under"]
 #: Directories worth seeding from: `launch`, plus the two that hold launch-manager component
 #: definitions naming the package and launch file they start.
 DEFAULT_SEED_DIRS = ("launch", "launch_manager_components", "launch_manager_configs")
+
+#: How many unfollowable includes to list before summarising the rest as a count.
+LISTED_UNREAD = 5
 
 
 def workspace_is_available() -> bool:
@@ -66,29 +70,21 @@ def check(package_dir: str, args: Optional[dict] = None) -> "tuple[Walk, list, l
         if os.path.isdir(os.path.join(package_dir, name))
     ]
 
-    references: list = []
-    edges: list = []
-    visited: list = []
-    seen: set = set()
-
-    for seed in seeds:
-        walk = scan_directory(seed, args=args)
-        references.extend(walk.references)
-        edges.extend(walk.edges)
-        for one in walk.visited:
-            if one not in seen:
-                seen.add(one)
-                visited.append(one)
-
-    walk = Walk(references=references, edges=edges, visited=visited)
+    # One walk over every seed directory, so a file reachable from two of them is read - and
+    # reported - once.
+    walk = scan_directories(seeds, args=args)
 
     missing = sorted(
         {one.package for one in walk.references if not _installed(one.package)}
     )
 
-    # An include unfollowable *because its package is absent* is already reported as missing.
+    # A dead include is one whose package is here and whose file is not. An include whose
+    # package is absent is already reported as missing, and one whose name still holds a
+    # substitution names no package at all - both belong in the unfollowable list instead.
     dead = [
-        one for one in walk.unresolved if one.package and one.package not in missing
+        one
+        for one in walk.unresolved
+        if is_literal_package(one.package) and one.package not in missing
     ]
 
     return walk, missing, dead
@@ -135,9 +131,11 @@ def _report(package_dir: str, walk: Walk, missing: list, dead: list) -> None:
         # Printed even when nothing is wrong, so a clean result that skipped half the tree
         # does not read like one that did not.
         print(f"  {len(unread)} include(s) could not be followed and were not checked:")
-        for edge in unread[:5]:
+        for edge in unread[:LISTED_UNREAD]:
             target = f"{edge.package or '(computed)'}/{edge.launch_file}"
             print(f"      {_where(edge.file, package_dir)}:{edge.line}  {target}")
+        if len(unread) > LISTED_UNREAD:
+            print(f"      ... and {len(unread) - LISTED_UNREAD} more")
 
 
 def main() -> None:

--- a/package_xml_validation/check_launch_tree.py
+++ b/package_xml_validation/check_launch_tree.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Does everything this launch tree reaches actually exist here?
+
+Follows every include from a package's launch files, across package boundaries, and reports
+two kinds of finding:
+
+* **a package that is not installed** - the launch file names it, nothing here provides it;
+* **an include that leads nowhere** - the package is there, the launch file it names is not.
+
+Neither is fixable by editing a manifest, so this is a separate entry point from
+`package_xml_validator` rather than a flag on it: it only reports, and it resolves through
+`AMENT_PREFIX_PATH`, so it needs a built and sourced workspace. Without one it says so and
+skips, rather than reporting every package as missing.
+"""
+
+from typing import Optional
+import argparse
+import os
+import sys
+
+from .helpers.find_launch_dependencies import Walk, scan_directory
+
+__all__ = ["check", "main"]
+
+
+#: Directories worth seeding from: `launch`, plus the two that hold launch-manager component
+#: definitions naming the package and launch file they start.
+DEFAULT_SEED_DIRS = ("launch", "launch_manager_components", "launch_manager_configs")
+
+
+def workspace_is_available() -> bool:
+    """Whether there is anything to resolve packages against."""
+    return any(
+        part for part in os.environ.get("AMENT_PREFIX_PATH", "").split(os.pathsep)
+    )
+
+
+def _installed(package: str) -> bool:
+    from .helpers.find_launch_dependencies import default_share_lookup
+
+    return default_share_lookup(package) is not None
+
+
+def check(package_dir: str, args: Optional[dict] = None) -> "tuple[Walk, list, list]":
+    """Follow this package's launch tree. Returns `(walk, missing packages, dead includes)`."""
+    seeds = [
+        os.path.join(package_dir, name)
+        for name in DEFAULT_SEED_DIRS
+        if os.path.isdir(os.path.join(package_dir, name))
+    ]
+
+    references: list = []
+    edges: list = []
+    visited: list = []
+    seen: set = set()
+
+    for seed in seeds:
+        walk = scan_directory(seed, args=args)
+        references.extend(walk.references)
+        edges.extend(walk.edges)
+        for one in walk.visited:
+            if one not in seen:
+                seen.add(one)
+                visited.append(one)
+
+    walk = Walk(references=references, edges=edges, visited=visited)
+
+    missing = sorted(
+        {one.package for one in walk.references if not _installed(one.package)}
+    )
+
+    # An include unfollowable *because its package is absent* is already reported as missing.
+    dead = [
+        one for one in walk.unresolved if one.package and one.package not in missing
+    ]
+
+    return walk, missing, dead
+
+
+def _where(path: str, package_dir: str) -> str:
+    """A path a reader can act on.
+
+    Relative while the file belongs to this package, absolute once it does not - a chain of
+    `../..` out of the workspace and into `/opt` tells nobody anything.
+    """
+    relative = os.path.relpath(path, package_dir)
+    return os.path.abspath(path) if relative.startswith("..") else relative
+
+
+def _report(package_dir: str, walk: Walk, missing: list, dead: list) -> None:
+    name = os.path.basename(os.path.abspath(package_dir))
+    print(
+        f"{name}: read {len(walk.visited)} launch file(s), {len(walk.packages)} package(s)"
+    )
+
+    where: dict = {}
+    for one in walk.references:
+        where.setdefault(one.package, one)
+
+    for package in missing:
+        cited = where.get(package)
+        print(f"  {package} is not installed in this workspace")
+        if cited:
+            print(f"      referenced by {_where(cited.file, package_dir)}:{cited.line}")
+
+    for edge in dead:
+        print(f"  {edge.package} does not ship {edge.launch_file}")
+        print(f"      referenced by {_where(edge.file, package_dir)}:{edge.line}")
+
+    # Edges the two sections above have not already accounted for.
+    explained = set(missing)
+    unread = [
+        one
+        for one in walk.unresolved
+        if one not in dead and one.package not in explained
+    ]
+    if unread:
+        # Printed even when nothing is wrong, so a clean result that skipped half the tree
+        # does not read like one that did not.
+        print(f"  {len(unread)} include(s) could not be followed and were not checked:")
+        for edge in unread[:5]:
+            target = f"{edge.package or '(computed)'}/{edge.launch_file}"
+            print(f"      {_where(edge.file, package_dir)}:{edge.line}  {target}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check that everything a package's launch tree references exists here."
+    )
+    parser.add_argument(
+        "src", nargs="*", default=["."], help="Package directories to check."
+    )
+    parser.add_argument(
+        "--error",
+        action="store_true",
+        help="Exit non-zero on findings. Warns only by default, so it can be introduced to a "
+        "repository that already has some.",
+    )
+    parser.add_argument(
+        "--arg",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="A value for $(var NAME), overriding the default a launch file declares. Repeat "
+        "for several. Without these the tree is followed as its defaults describe it.",
+    )
+    parsed = parser.parse_args()
+
+    if not workspace_is_available():
+        # Not a failure: with nothing to resolve against, every package would read as missing.
+        print(
+            "check-launch-tree: AMENT_PREFIX_PATH is empty, so packages cannot be resolved - "
+            "the launch tree was not checked. Source the workspace to enable this check."
+        )
+        return
+
+    args = {}
+    for item in parsed.arg:
+        name, _, value = item.partition("=")
+        if name:
+            args[name] = value
+
+    findings = 0
+    for package_dir in parsed.src or ["."]:
+        walk, missing, dead = check(package_dir, args or None)
+        _report(package_dir, walk, missing, dead)
+        findings += len(missing) + len(dead)
+
+    if findings and parsed.error:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -602,7 +602,7 @@ def _component_edges(path: str, text: str) -> list[Edge]:
             edges.append(
                 Edge(
                     package[0].value,
-                    os.path.join("launch", launch_file[0].value),
+                    launch_file[0].value,
                     path,
                     package[1].start_mark.line + 1,
                     None,

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -5,64 +5,122 @@ find_launch_dependencies.py
 Recursively search a ROS 2 package's launch/ folder and extract
 all referenced ROS 2 package names via a small set of regexes.
 
-Now ignores matches that occur inside comments:
+Ignores matches that occur inside comments:
 - Python: # line comments, and triple-quoted blocks
 - XML/.launch: <!-- ... --> comments
 - YAML: # line comments
+
+Each pattern also declares which file formats it applies to, because a pattern is a piece of
+syntax and the same characters mean different things in different languages. `pkg:` is a
+mapping key in YAML and a type annotation in Python: applied to Python source it reported the
+annotation `pkg: str` as a package named `str`, and the string literal
+`"pkg:robot.launch.yaml"` as a package named `robot`.
 """
 
 import logging
 import os
 import re
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-REGEX_EXPR = [
+# Which file formats a pattern is allowed to match. A pattern is a piece of *syntax*, and the
+# same characters mean different things in different languages: `pkg:` is a mapping key in YAML
+# and a type annotation in Python, so a pattern written for one produces nonsense in the other.
+# TOML already had this treatment; every pattern gets it now.
+FORMAT_YAML = "yaml"
+FORMAT_XML = "xml"
+FORMAT_PY = "py"
+FORMAT_TOML = "toml"
+
+#: Formats a pattern applies to when its syntax is unambiguous everywhere - `$(find-pkg-share x)`
+#: means the same thing wherever it appears, including inside a Python string handed to a
+#: frontend launch file.
+ANY_FORMAT = frozenset({FORMAT_YAML, FORMAT_XML, FORMAT_PY, FORMAT_TOML})
+
+#: `(regex, formats)`. The formats are the point: see the note above.
+PATTERNS = [
     # YAML-style:  pkg: <pkg_name>
-    r"pkg\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    #
+    # Anchored to the start of a line, allowing the leading `- ` of a sequence item. Without
+    # the anchor any key *ending* in `pkg` matches - `mypkg: foo` yielded a package named
+    # `foo`. Not applied to Python, where `pkg: str` is a type annotation and used to yield a
+    # package named `str`, nor to a string literal that happens to contain `pkg:`.
+    (r"(?m)^[\s\-]*pkg\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?", {FORMAT_YAML, FORMAT_XML}),
     # Hector launch component:  package: <pkg_name>
-    r"package\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    (
+        r"(?m)^[\s\-]*package\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+        {FORMAT_YAML, FORMAT_XML},
+    ),
     # Python Node-family constructors: Node / LifecycleNode / ComposableNode /
     # ComposableLifecycleNode (..., package='<pkg_name>', ...)
-    r"(?:^|[^\w])(?:Node|LifecycleNode|ComposableNode|ComposableLifecycleNode)\s*\(\s*[^)]*?\bpackage\s*=\s*['\"]([A-Za-z0-9_]+)['\"]",
+    (
+        r"(?:^|[^\w])(?:Node|LifecycleNode|ComposableNode|ComposableLifecycleNode)\s*\(\s*[^)]*?\bpackage\s*=\s*['\"]([A-Za-z0-9_]+)['\"]",
+        {FORMAT_PY},
+    ),
     # XML node tag: <node pkg="foo" ...>
-    r"<node[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    (r"<node[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?", {FORMAT_XML}),
     # XML composable node: <composable_node pkg="foo" ...>
-    r"<composable_node[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    (r"<composable_node[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?", {FORMAT_XML}),
     # XML node container: <node_container pkg="foo" ...>
-    r"<node_container[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?",
+    (r"<node_container[^>]*?\bpkg\s*=\s*['\"]?([A-Za-z0-9_]+)['\"]?", {FORMAT_XML}),
     # get_package_share_directory('foo')
-    r"get_package_share_directory\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    (r"get_package_share_directory\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)", {FORMAT_PY}),
     # get_package_share_path('foo')
-    r"get_package_share_path\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    (r"get_package_share_path\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)", {FORMAT_PY}),
     # get_package_prefix('foo')
-    r"get_package_prefix\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    (r"get_package_prefix\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)", {FORMAT_PY}),
     # FindPackageShare('foo')
-    r"FindPackageShare\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    (r"FindPackageShare\(\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)", {FORMAT_PY}),
     # FindPackageShare(package='foo')
-    r"FindPackageShare\(\s*package\s*=\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    (r"FindPackageShare\(\s*package\s*=\s*['\"]([A-Za-z0-9_]+)['\"]\s*\)", {FORMAT_PY}),
     # FindPackagePrefix('foo') / FindPackagePrefix(package='foo')
-    r"FindPackagePrefix\(\s*(?:package\s*=\s*)?['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+    (
+        r"FindPackagePrefix\(\s*(?:package\s*=\s*)?['\"]([A-Za-z0-9_]+)['\"]\s*\)",
+        {FORMAT_PY},
+    ),
     # $(find-pkg-share foo)
-    r"\$\(\s*find-pkg-share\s+([A-Za-z0-9_]+)\s*\)",
+    (r"\$\(\s*find-pkg-share\s+([A-Za-z0-9_]+)\s*\)", ANY_FORMAT),
     # $(find-pkg-prefix foo)
-    r"\$\(\s*find-pkg-prefix\s+([A-Za-z0-9_]+)\s*\)",
+    (r"\$\(\s*find-pkg-prefix\s+([A-Za-z0-9_]+)\s*\)", ANY_FORMAT),
     # better_launch Python:  bl.node("pkg", ...)  /  bl.include("pkg", ...)
-    r"\bbl\.node\(\s*['\"]([A-Za-z0-9_]+)['\"]",
-    r"\bbl\.include\(\s*['\"]([A-Za-z0-9_]+)['\"]",
-]
-
-COMPILED = [re.compile(rx) for rx in REGEX_EXPR]
-
-# TOML patterns are kept separate and only applied to .toml files under a
-# launch/ directory, to avoid false positives from arbitrary TOML configs.
-TOML_REGEX_EXPR = [
+    (r"\bbl\.node\(\s*['\"]([A-Za-z0-9_]+)['\"]", {FORMAT_PY}),
+    (r"\bbl\.include\(\s*['\"]([A-Za-z0-9_]+)['\"]", {FORMAT_PY}),
     # better_launch TOML:  package = "pkg"
-    r"^\s*package\s*=\s*['\"]([A-Za-z0-9_]+)['\"]",
+    (r"(?m)^\s*package\s*=\s*['\"]([A-Za-z0-9_]+)['\"]", {FORMAT_TOML}),
 ]
 
-TOML_COMPILED = [re.compile(rx, re.MULTILINE) for rx in TOML_REGEX_EXPR]
+COMPILED_PATTERNS = [(re.compile(rx), formats) for rx, formats in PATTERNS]
+
+#: Kept for anything importing the old names. `COMPILED` no longer decides what is applied to
+#: a file - :py:func:`_patterns_for` does, by format.
+REGEX_EXPR = [rx for rx, _ in PATTERNS]
+COMPILED = [rx for rx, _ in COMPILED_PATTERNS]
+TOML_REGEX_EXPR = [rx for rx, formats in PATTERNS if formats == {FORMAT_TOML}]
+TOML_COMPILED = [re.compile(rx) for rx in TOML_REGEX_EXPR]
+
+
+def _format_of(path: str) -> Optional[str]:
+    """Which syntax a file is written in, or None if we do not scan it."""
+    s = path.lower()
+    if s.endswith(".py"):
+        return FORMAT_PY
+    if s.endswith(".xml") or s.endswith(".launch"):
+        return FORMAT_XML
+    if s.endswith((".yaml", ".yml")):
+        return FORMAT_YAML
+    if s.endswith(".toml"):
+        return FORMAT_TOML
+    return None
+
+
+def _patterns_for(fmt: str) -> list[tuple["re.Pattern[str]", int]]:
+    """The compiled patterns that mean anything in `fmt`."""
+    return [
+        (rx, i) for i, (rx, formats) in enumerate(COMPILED_PATTERNS) if fmt in formats
+    ]
+
 
 _TRIPLE_QUOTE_BLOCK = re.compile(r"(?s)(['\"]{3})(?:.*?)(\1)")
 _XML_COMMENT_BLOCK = re.compile(r"(?s)<!--.*?-->")
@@ -236,24 +294,22 @@ def scan_file(path: str, found: set[str], verbose: bool = False) -> None:
         None.
 
     """
+    fmt = _format_of(path)
+    if fmt is None:
+        return
+
+    # A TOML file is only a launch file when it is under a launch/ directory - `package = "x"`
+    # is far too common a line in ordinary project TOML to read as a dependency anywhere else.
+    # The other formats identify themselves by their own syntax and need no such scoping.
+    if fmt == FORMAT_TOML and not _is_under_launch_dir(path):
+        return
+
     with open(path, encoding="utf-8") as f:
         text = f.read()
 
     text = _decomment_for_suffix(path, text)
 
-    is_toml = path.lower().endswith(".toml")
-    if is_toml:
-        # Only honour TOML matches if the file is scoped under a launch/ dir,
-        # to avoid false positives from arbitrary project TOML configs.
-        if not _is_under_launch_dir(path):
-            return
-        patterns = TOML_COMPILED
-        sources = TOML_REGEX_EXPR
-    else:
-        patterns = COMPILED
-        sources = REGEX_EXPR
-
-    for i, rx in enumerate(patterns):
+    for rx, index in _patterns_for(fmt):
         for m in rx.finditer(text):
             pkg = m.group(1)
             found.add(pkg)
@@ -262,7 +318,7 @@ def scan_file(path: str, found: set[str], verbose: bool = False) -> None:
                     "Found package '%s' in %s with regex %s",
                     pkg,
                     os.path.basename(path),
-                    sources[i],
+                    REGEX_EXPR[index],
                 )
 
 

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -11,32 +11,28 @@ Ignores matches that occur inside comments:
 - YAML: # line comments
 
 Each pattern also declares which file formats it applies to, because a pattern is a piece of
-syntax and the same characters mean different things in different languages. `pkg:` is a
-mapping key in YAML and a type annotation in Python: applied to Python source it reported the
-annotation `pkg: str` as a package named `str`, and the string literal
-`"pkg:robot.launch.yaml"` as a package named `robot`.
+syntax and the same characters mean different things in different languages.
 """
 
+import ast
+import glob
 import logging
 import os
 import re
-from typing import Optional
+from typing import Callable, NamedTuple, Optional
 
 logger = logging.getLogger(__name__)
 
 
-# Which file formats a pattern is allowed to match. A pattern is a piece of *syntax*, and the
-# same characters mean different things in different languages: `pkg:` is a mapping key in YAML
-# and a type annotation in Python, so a pattern written for one produces nonsense in the other.
-# TOML already had this treatment; every pattern gets it now.
+# Which file formats a pattern is allowed to match.
 FORMAT_YAML = "yaml"
 FORMAT_XML = "xml"
 FORMAT_PY = "py"
 FORMAT_TOML = "toml"
 
-#: Formats a pattern applies to when its syntax is unambiguous everywhere - `$(find-pkg-share x)`
-#: means the same thing wherever it appears, including inside a Python string handed to a
-#: frontend launch file.
+
+#: For patterns whose syntax means the same thing in every format, such as
+#: `$(find-pkg-share x)`.
 ANY_FORMAT = frozenset({FORMAT_YAML, FORMAT_XML, FORMAT_PY, FORMAT_TOML})
 
 #: `(regex, formats)`. The formats are the point: see the note above.
@@ -51,7 +47,7 @@ PATTERNS = [
     # Hector launch component:  package: <pkg_name>
     (
         r"(?m)^[\s\-]*package\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?",
-        {FORMAT_YAML, FORMAT_XML},
+        {FORMAT_YAML},
     ),
     # Python Node-family constructors: Node / LifecycleNode / ComposableNode /
     # ComposableLifecycleNode (..., package='<pkg_name>', ...)
@@ -126,6 +122,16 @@ _TRIPLE_QUOTE_BLOCK = re.compile(r"(?s)(['\"]{3})(?:.*?)(\1)")
 _XML_COMMENT_BLOCK = re.compile(r"(?s)<!--.*?-->")
 
 
+def _blank_out(pattern: "re.Pattern[str]", text: str) -> str:
+    """Remove a block but keep the lines it spanned.
+
+    Deleting a multi-line comment outright shifts every line after it, which is invisible
+    while matches are only collected as names and wrong the moment one is reported with a line
+    number. The newlines are kept so a match's position still means what it says.
+    """
+    return pattern.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+
+
 def _strip_hash_line_comments_outside_strings(text: str) -> str:
     """
     Remove '#' to end-of-line comments that occur OUTSIDE of single/double quoted strings.
@@ -198,8 +204,8 @@ def _decomment_python(text: str) -> str:
         Text with comments removed.
 
     """
-    # 1) drop triple-quoted blocks entirely
-    text = _TRIPLE_QUOTE_BLOCK.sub("", text)
+    # 1) drop triple-quoted blocks, keeping the lines they spanned
+    text = _blank_out(_TRIPLE_QUOTE_BLOCK, text)
     # 2) drop '#' comments outside of quoted strings
     text = _strip_hash_line_comments_outside_strings(text)
     return text
@@ -215,7 +221,7 @@ def _decomment_xml(text: str) -> str:
         Text with XML comments removed.
 
     """
-    return _XML_COMMENT_BLOCK.sub("", text)
+    return _blank_out(_XML_COMMENT_BLOCK, text)
 
 
 def _decomment_yaml(text: str) -> str:
@@ -300,7 +306,6 @@ def scan_file(path: str, found: set[str], verbose: bool = False) -> None:
 
     # A TOML file is only a launch file when it is under a launch/ directory - `package = "x"`
     # is far too common a line in ordinary project TOML to read as a dependency anywhere else.
-    # The other formats identify themselves by their own syntax and need no such scoping.
     if fmt == FORMAT_TOML and not _is_under_launch_dir(path):
         return
 
@@ -351,3 +356,549 @@ def scan_files(launch_dir: str, verbose: bool = False) -> list[str]:
             elif fn.endswith(".toml") and _is_under_launch_dir(full):
                 scan_file(full, pkgs, verbose)
     return sorted(pkgs)
+
+
+# ── Following a launch tree from a seed ──────────────────────────────────────────────────
+#
+# `scan_files` covers every launch file a package ships, which is the manifest question.
+# Seeding from one launch file asks instead what a particular system launches: it descends
+# into other packages' launch files, and ignores files the seed does not reach.
+#
+# The walk follows include *edges* only. A package named by `pkg:` on a node is a leaf - there
+# is no launch file behind it, and scanning everything that package ships would report launch
+# files nobody runs.
+
+
+class Reference(NamedTuple):
+    """One package name, and where it was written."""
+
+    package: str
+    file: str
+    line: int
+
+
+class Edge(NamedTuple):
+    """An include: one launch file naming another, and whether we could find it."""
+
+    package: str
+    launch_file: str
+    file: str
+    line: int
+    resolved: Optional[str]
+
+
+class Walk(NamedTuple):
+    """What following a seed found.
+
+    A launch tree is only partly made of includes, so parts of it are outside this scan:
+
+    * a node that reads a config and starts processes of its own is opaque;
+    * `if:` / `unless:` branches are collected as a union, not as the set one run would take;
+    * anything assembled at runtime (`$(eval ...)`, `$(command ...)`) is left unresolved.
+    """
+
+    references: list[Reference]
+    """Every package named anywhere in the tree, with provenance. May repeat a package."""
+
+    edges: list[Edge]
+    """Every include encountered, resolved or not."""
+
+    visited: list[str]
+    """The launch files actually read, seed first."""
+
+    @property
+    def packages(self) -> list[str]:
+        return sorted({one.package for one in self.references})
+
+    @property
+    def unresolved(self) -> list[Edge]:
+        """Includes this could not follow - a package that is not installed, a file that is
+        not where it should be, or a name built from a substitution.
+
+        Empty means nothing this scan can see was left unfollowed, which is not the same as
+        the tree being fully explored. See the class docstring.
+        """
+        return [one for one in self.edges if one.resolved is None]
+
+
+#: `$(find-pkg-share x)/some/path` - the path is kept so an include can be resolved from it.
+#: The package part is not restricted to an identifier, because a launch file may build it
+#: from a substitution: `$(find-pkg-share $(var robot)_sim)/launch/spawn.launch.py`. Such a
+#: name is reported unresolved rather than skipped. One level of nesting covers every form
+#: seen in practice.
+_SHARE_PATH = re.compile(
+    r"\$\(\s*find-pkg-share\s+((?:[^()\s]|\([^()]*\))+)\s*\)/([A-Za-z0-9_./\-]+)"
+)
+
+#: A package name we could look up, as opposed to one assembled at launch time.
+_LITERAL_PACKAGE = re.compile(r"^[A-Za-z0-9_]+$")
+
+#: A launch-manager component: `package:` and then `launch_file:` in the same block.
+_COMPONENT_LAUNCH = re.compile(
+    r"(?m)^[\s\-]*package\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?"
+    r"(?:.*\n){0,6}?[\s\-]*launch_file\s*:\s*['\"]?([A-Za-z0-9_.\-]+)['\"]?"
+)
+
+_LAUNCH_SUFFIXES = (".launch.py", ".launch.xml", ".launch.yaml", ".launch.yml")
+
+
+def _find_in_share(share: str, relative: str) -> Optional[str]:
+    """The launch file inside a package's share directory, or None.
+
+    The written path first, then the same basename anywhere under the package. The fallback
+    exists for launch-manager components, which name a launch file by bare filename and let
+    the manager find it: `nav2.yaml` says `nav2.launch.yaml`, the file is at
+    `launch/navigation/nav2.launch.yaml`.
+
+    First match in sorted order when a basename occurs twice.
+    """
+    direct = os.path.join(share, relative)
+    if os.path.isfile(direct):
+        return direct
+
+    matches = sorted(
+        glob.glob(os.path.join(share, "**", os.path.basename(relative)), recursive=True)
+    )
+    return matches[0] if matches else None
+
+
+def _line_of(text: str, position: int) -> int:
+    return text.count("\n", 0, position) + 1
+
+
+def _looks_like_a_launch_file(path: str) -> bool:
+    """A path under `launch/`, or named `*.launch.*`.
+
+    Neither test alone is enough: a launch directory also holds files that are not launch
+    files, and `$(find-pkg-share x)/config/params.yaml` has an extension we scan.
+    """
+    lowered = path.lower()
+    return lowered.endswith(_LAUNCH_SUFFIXES) or "/launch/" in f"/{lowered}"
+
+
+def default_share_lookup(package: str) -> Optional[str]:
+    """Where a package's share directory is, read from AMENT_PREFIX_PATH.
+
+    Not `ament_index_python`, so the library works without ROS on the path. Pass your own
+    lookup to `scan_from` to resolve against something else.
+    """
+    for prefix in os.environ.get("AMENT_PREFIX_PATH", "").split(os.pathsep):
+        if not prefix:
+            continue
+        share = os.path.join(prefix, "share", package)
+        if os.path.isdir(share):
+            return share
+    return None
+
+
+def scan_file_detailed(path: str, scope: Optional[dict] = None) -> list[Reference]:
+    """Every package `path` names, each with the line it was named on.
+
+    The same matches `scan_file` collects, keeping their provenance.
+
+    `scope` expands `$(var x)` first, so a package whose name is assembled from an argument is
+    reported under the name it will actually have. Substitutions never span lines, so the line
+    numbers survive the expansion.
+    """
+    fmt = _format_of(path)
+    if fmt is None:
+        return []
+
+    if fmt == FORMAT_TOML and not _is_under_launch_dir(path):
+        return []
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except OSError:
+        return []
+
+    text = _decomment_for_suffix(path, text)
+    if scope:
+        text = expand_vars(text, scope)
+
+    found: list[Reference] = []
+    for rx, _ in _patterns_for(fmt):
+        for m in rx.finditer(text):
+            found.append(Reference(m.group(1), path, _line_of(text, m.start())))
+
+    return found
+
+
+def _edges_in(path: str, scope: Optional[dict] = None) -> list[Edge]:
+    """The includes `path` makes, before any attempt to resolve them.
+
+    Three kinds: a frontend `$(find-pkg-share ...)` substitution, a launch-manager component
+    naming a package and a file, and a Python `IncludeLaunchDescription`.
+    """
+    fmt = _format_of(path)
+    if fmt is None:
+        return []
+
+    edges: list[Edge] = []
+
+    if fmt == FORMAT_PY:
+        edges.extend(_python_edges(path))
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+    except OSError:
+        return edges
+
+    text = _decomment_for_suffix(path, text)
+    if scope:
+        text = expand_vars(text, scope)
+
+    for m in _SHARE_PATH.finditer(text):
+        package, relative = m.group(1), m.group(2)
+        if _looks_like_a_launch_file(relative):
+            # A computed name is kept as written; `_walk` leaves it unresolved.
+            edges.append(Edge(package, relative, path, _line_of(text, m.start()), None))
+
+    for m in _COMPONENT_LAUNCH.finditer(text):
+        package, launch_file = m.group(1), m.group(2)
+        edges.append(
+            Edge(
+                package,
+                os.path.join("launch", launch_file),
+                path,
+                _line_of(text, m.start()),
+                None,
+            )
+        )
+
+    return edges
+
+
+# ── Resolving what a launch file leaves to be filled in later ────────────────────────────
+
+#: `$(var name)`. Other substitution types - `$(env x)`, `$(eval ...)`, `$(command ...)` -
+#: depend on the environment or on running code and are left unexpanded.
+_VAR = re.compile(r"\$\(\s*var\s+([A-Za-z0-9_]+)\s*\)")
+
+
+def declared_args(path: str) -> dict:
+    """The `{name: default}` a YAML frontend launch file declares.
+
+    Only defaults that are written down. An argument with no default is one the caller has to
+    supply, and guessing one would resolve an include to a file this system never loads.
+    """
+    if _format_of(path) != FORMAT_YAML:
+        return {}
+
+    try:
+        import yaml
+
+        with open(path, encoding="utf-8") as f:
+            document = yaml.safe_load(f) or {}
+    except Exception:
+        # Unparsable: nothing to expand from, so names stay as written and end up unresolved.
+        return {}
+
+    if not isinstance(document, dict):
+        return {}
+
+    found = {}
+    for entry in document.get("launch") or []:
+        if not isinstance(entry, dict):
+            continue
+        arg = entry.get("arg")
+        if isinstance(arg, dict) and "name" in arg and "default" in arg:
+            found[str(arg["name"])] = str(arg["default"])
+
+    return found
+
+
+def expand_vars(text: str, scope: dict, rounds: int = 10) -> str:
+    """Replace `$(var x)` from `scope`, repeatedly, leaving unknown names as written.
+
+    Repeatedly because a default may cite another argument (`robot_name: "$(var robot)"`).
+    Bounded rather than run to a fixpoint, so mutually defined arguments cannot hang a scan.
+    """
+    for _ in range(rounds):
+        expanded = _VAR.sub(lambda m: scope.get(m.group(1), m.group(0)), text)
+        if expanded == text:
+            return expanded
+        text = expanded
+
+    return text
+
+
+def _scope_for(path: str, args: Optional[dict]) -> dict:
+    """What `$(var x)` means in this file: its own declared defaults, then the caller's values.
+
+    The caller's win, so a caller that knows what it is about to launch with follows the tree
+    that will come up rather than the one the defaults describe.
+    """
+    scope = declared_args(path)
+    if args:
+        scope.update({str(k): str(v) for k, v in args.items()})
+
+    # A default may name another argument, so the table has to be expanded against itself.
+    return {name: expand_vars(value, scope) for name, value in scope.items()}
+
+
+# ── Includes written in Python ───────────────────────────────────────────────────────────
+
+#: Calls that name a package's share directory. Everything else is reported as an include
+#: this scan could not follow - see `_python_edges`.
+_SHARE_CALLS = (
+    "FindPackageShare",
+    "get_package_share_directory",
+    "get_package_share_path",
+)
+
+
+def _string_of(node: ast.AST) -> Optional[str]:
+    return (
+        node.value
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        else None
+    )
+
+
+def _path_expression(node: ast.AST, bound: dict) -> "Optional[tuple[str, list[str]]]":
+    """`(package, path segments)` for an expression that names a file inside a package.
+
+    Handles the three ways one is written, and their combinations:
+
+        get_package_share_directory("x")            -> ("x", [])
+        os.path.join(<expr>, "launch", "a.py")      -> the expr's package, its parts + these
+        PathJoinSubstitution([<expr>, "launch"])    -> the same
+
+    `bound` carries names already resolved, so a chain of assignments works.
+
+    Returns None as soon as anything is not a literal or a known name. Control flow is not
+    followed: a name assigned twice resolves to the last assignment seen, so the result is
+    only used to find more launch files to read, never to claim one runs.
+    """
+    if isinstance(node, ast.Name):
+        return bound.get(node.id)
+
+    if not isinstance(node, ast.Call):
+        return None
+
+    if getattr(node.func, "id", "") in _SHARE_CALLS:
+        named = _string_of(node.args[0]) if node.args else None
+        return (named, []) if named else None
+
+    items: "list[ast.AST]" = []
+    if getattr(node.func, "attr", "") == "join":
+        items = list(node.args)
+    elif getattr(node.func, "id", "") == "PathJoinSubstitution":
+        if node.args and isinstance(node.args[0], (ast.List, ast.Tuple)):
+            items = list(node.args[0].elts)
+
+    if not items:
+        return None
+
+    package: Optional[str] = None
+    parts: list[str] = []
+
+    for item in items:
+        literal = _string_of(item)
+        if literal is not None:
+            parts.append(literal)
+            continue
+
+        resolved = _path_expression(item, bound)
+        if resolved is None:
+            return None
+        if package is not None:
+            # Two package roots in one path is not something to guess at.
+            return None
+        package, parts = resolved[0], list(resolved[1]) + parts
+
+    return (package, parts) if package else None
+
+
+def _share_bindings(tree: ast.Module, rounds: int = 3) -> dict:
+    """Every name bound to a location inside a package, anywhere in the file.
+
+    Anywhere rather than at module level, since the idiom is as often a local inside
+    `generate_launch_description`. Repeated because one binding may be built from another and
+    `ast.walk` does not visit them in dependency order.
+    """
+    bound: dict = {}
+
+    for _ in range(rounds):
+        before = len(bound)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if not isinstance(target, ast.Name):
+                continue
+
+            resolved = _path_expression(node.value, bound)
+            if resolved is not None:
+                bound[target.id] = resolved
+
+        if len(bound) == before:
+            break
+
+    return bound
+
+
+def _python_edges(path: str) -> "list[Edge]":
+    """Every `IncludeLaunchDescription` in a Python launch file.
+
+    Resolved where the package and path are literals. Everything else is still reported, with
+    its line, as an include this scan could not read.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            tree = ast.parse(f.read())
+    except (OSError, SyntaxError):
+        return []
+
+    edges: list[Edge] = []
+    bound = _share_bindings(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if getattr(node.func, "id", "") != "IncludeLaunchDescription":
+            continue
+
+        package: Optional[str] = None
+        parts: list[str] = []
+        for inner in ast.walk(node):
+            resolved = (
+                _path_expression(inner, bound) if isinstance(inner, ast.Call) else None
+            )
+            if resolved is not None and resolved[1]:
+                package, parts = resolved
+                break
+
+        if package and parts:
+            edges.append(Edge(package, os.path.join(*parts), path, node.lineno, None))
+        else:
+            edges.append(
+                Edge(
+                    "",
+                    "an IncludeLaunchDescription this scan could not read",
+                    path,
+                    node.lineno,
+                    None,
+                )
+            )
+
+    return edges
+
+
+def scan_directory(
+    directory: str,
+    share_lookup: Callable[[str], Optional[str]] = default_share_lookup,
+    args: Optional[dict] = None,
+    max_depth: int = 12,
+) -> Walk:
+    """Every launch file in `directory`, followed - one walk, not one per file.
+
+    The recursive counterpart to :py:func:`scan_files`: that reads what a package ships, this
+    also reads what those files pull in. Sibling launch files tend to include the same things,
+    so a single shared walk reads each of them once.
+
+    Args:
+        directory: Scanned recursively for launch files to use as seeds.
+        share_lookup: `package -> share directory or None`.
+        args: Values for `$(var x)`, as in :py:func:`scan_from`.
+        max_depth: How far to follow includes below each seed.
+
+    Returns:
+        A :py:class:`Walk` over all of them.
+
+    """
+    seeds = []
+
+    for root, _, files in os.walk(directory):
+        for name in sorted(files):
+            full = os.path.join(root, name)
+            if _format_of(full) is None:
+                continue
+            if _format_of(full) == FORMAT_TOML and not _is_under_launch_dir(full):
+                continue
+            seeds.append(full)
+
+    return _walk(seeds, share_lookup, args, max_depth)
+
+
+def scan_from(
+    seed: str,
+    share_lookup: Callable[[str], Optional[str]] = default_share_lookup,
+    args: Optional[dict] = None,
+    max_depth: int = 12,
+) -> Walk:
+    """Follow a launch file's includes, collecting every package the tree names.
+
+    Args:
+        seed: The launch file to start from.
+        share_lookup: `package -> share directory or None`. Defaults to AMENT_PREFIX_PATH.
+        args: Values for `$(var x)`, overriding any default the file declares. Pass what the
+            system will be launched with to follow the tree that will come up; omit them to
+            follow the one the defaults describe. Applied at any depth.
+        max_depth: How far to follow includes. A guard against runaway recursion.
+
+    Returns:
+        A :py:class:`Walk`. Includes that could not be resolved are in `unresolved` rather
+        than being guessed at or dropped, so a caller reporting coverage knows how much of
+        the tree went unread.
+
+    """
+    return _walk([seed], share_lookup, args, max_depth)
+
+
+def _walk(
+    seeds: "list[str]",
+    share_lookup: Callable[[str], Optional[str]],
+    args: Optional[dict],
+    max_depth: int,
+) -> Walk:
+    """The walk itself, over one seed or many.
+
+    The visited set spans every seed, so a file two seeds both reach is read - and reported -
+    once.
+    """
+    references: list[Reference] = []
+    edges: list[Edge] = []
+    visited: list[str] = []
+    seen: set[str] = set()
+
+    queue = [(os.path.abspath(one), 0) for one in seeds]
+
+    while queue:
+        current, depth = queue.pop(0)
+
+        if current in seen or depth > max_depth:
+            continue
+        seen.add(current)
+
+        if not os.path.isfile(current):
+            continue
+
+        visited.append(current)
+
+        # Each file expands with its own declared defaults under the caller's values, so a
+        # child that declares an argument the parent never mentions still resolves.
+        scope = _scope_for(current, args)
+
+        references.extend(scan_file_detailed(current, scope))
+
+        for edge in _edges_in(current, scope):
+            if not _LITERAL_PACKAGE.match(edge.package):
+                # Built from a substitution, so there is nothing to look up.
+                edges.append(edge)
+                continue
+
+            share = share_lookup(edge.package)
+            target = _find_in_share(share, edge.launch_file) if share else None
+
+            if target is not None and os.path.isfile(target):
+                edges.append(edge._replace(resolved=target))
+                queue.append((target, depth + 1))
+            else:
+                edges.append(edge)
+
+    return Walk(references=references, edges=edges, visited=visited)

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -41,10 +41,9 @@ ANY_FORMAT = frozenset({FORMAT_YAML, FORMAT_XML, FORMAT_PY, FORMAT_TOML})
 PATTERNS = [
     # YAML-style:  pkg: <pkg_name>
     #
-    # Anchored to the start of a line, allowing the leading `- ` of a sequence item. Without
-    # the anchor any key *ending* in `pkg` matches - `mypkg: foo` yielded a package named
-    # `foo`. Not applied to Python, where `pkg: str` is a type annotation and used to yield a
-    # package named `str`, nor to a string literal that happens to contain `pkg:`.
+    # Anchored to the start of a line, allowing the leading `- ` of a sequence item, so a key
+    # merely *ending* in `pkg` is not read as one. Not applied to Python, where `pkg:` is a
+    # type annotation rather than a mapping key.
     (r"(?m)^[\s\-]*pkg\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?", {FORMAT_YAML, FORMAT_XML}),
     # Hector launch component:  package: <pkg_name>
     (
@@ -91,12 +90,9 @@ PATTERNS = [
 
 COMPILED_PATTERNS = [(re.compile(rx), formats) for rx, formats in PATTERNS]
 
-#: Kept for anything importing the old names. `COMPILED` no longer decides what is applied to
-#: a file - :py:func:`_patterns_for` does, by format.
+#: Pattern sources, indexed alongside `COMPILED_PATTERNS` so a match can name the regex it came
+#: from.
 REGEX_EXPR = [rx for rx, _ in PATTERNS]
-COMPILED = [rx for rx, _ in COMPILED_PATTERNS]
-TOML_REGEX_EXPR = [rx for rx, formats in PATTERNS if formats == {FORMAT_TOML}]
-TOML_COMPILED = [re.compile(rx) for rx in TOML_REGEX_EXPR]
 
 
 def _format_of(path: str) -> Optional[str]:
@@ -125,12 +121,7 @@ _XML_COMMENT_BLOCK = re.compile(r"(?s)<!--.*?-->")
 
 
 def _blank_out(pattern: "re.Pattern[str]", text: str) -> str:
-    """Remove a block but keep the lines it spanned.
-
-    Deleting a multi-line comment outright shifts every line after it, which is invisible
-    while matches are only collected as names and wrong the moment one is reported with a line
-    number. The newlines are kept so a match's position still means what it says.
-    """
+    """Remove a block, keeping the newlines it spanned so later match positions still hold."""
     return pattern.sub(lambda m: "\n" * m.group(0).count("\n"), text)
 
 
@@ -584,10 +575,7 @@ def _edges_in(path: str, scope: Optional[dict] = None) -> list[Edge]:
 def _component_edges(path: str, text: str) -> list[Edge]:
     """Launch-manager components in a YAML file: a mapping with `package` and `launch_file`.
 
-    Parsed rather than pattern-matched, so that the two keys have to belong to the *same*
-    mapping. A regex scanning a window of following lines paired a node-only component's
-    `package` with the next component's `launch_file`, which both invented a finding and left
-    the real include unfollowed.
+    Parsed rather than pattern-matched, so the two keys have to belong to the *same* mapping.
     """
     try:
         root = yaml.compose(text)
@@ -709,9 +697,8 @@ _SHARE_CALLS = (
 def _called_name(node: ast.Call) -> str:
     """The trailing name of a call target: `f(...)` and `a.b.f(...)` both give `f`.
 
-    Qualified calls are common in launch files - `launch.actions.IncludeLaunchDescription`,
-    `ament_index_python.get_package_share_directory` - and matching only `ast.Name` made them
-    invisible: no edge at all, rather than one reported as unreadable.
+    Launch files write these calls both ways - `launch.actions.IncludeLaunchDescription` as
+    often as the bare name - so the qualifier carries no information worth matching on.
     """
     func = node.func
     if isinstance(func, ast.Name):

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -442,6 +442,17 @@ _SHARE_PATH = re.compile(
 #: A package name we could look up, as opposed to one assembled at launch time.
 _LITERAL_PACKAGE = re.compile(r"^[A-Za-z0-9_]+$")
 
+
+def is_literal_package(name: str) -> bool:
+    """Whether `name` is a package name we could look up.
+
+    False for a name still holding a substitution. Callers reporting on an unresolved edge
+    need the distinction: an unexpanded `$(var robot)_sim` is an include nobody could follow,
+    not a package that failed to ship a file.
+    """
+    return bool(_LITERAL_PACKAGE.match(name))
+
+
 _LAUNCH_SUFFIXES = (".launch.py", ".launch.xml", ".launch.yaml", ".launch.yml")
 
 
@@ -873,16 +884,32 @@ def scan_directory(
         A :py:class:`Walk` over all of them.
 
     """
+    return scan_directories([directory], share_lookup, args, max_depth)
+
+
+def scan_directories(
+    directories: "list[str]",
+    share_lookup: Callable[[str], Optional[str]] = default_share_lookup,
+    args: Optional[dict] = None,
+    max_depth: int = 12,
+) -> Walk:
+    """:py:func:`scan_directory` over several directories, as a single walk.
+
+    A package keeps launch files in more than one directory and they include the same things,
+    so walking each directory separately reads - and reports - shared files once per
+    directory.
+    """
     seeds = []
 
-    for root, _, files in os.walk(directory):
-        for name in sorted(files):
-            full = os.path.join(root, name)
-            if _format_of(full) is None:
-                continue
-            if _format_of(full) == FORMAT_TOML and not _is_under_launch_dir(full):
-                continue
-            seeds.append(full)
+    for directory in directories:
+        for root, _, files in os.walk(directory):
+            for name in sorted(files):
+                full = os.path.join(root, name)
+                if _format_of(full) is None:
+                    continue
+                if _format_of(full) == FORMAT_TOML and not _is_under_launch_dir(full):
+                    continue
+                seeds.append(full)
 
     return _walk(seeds, share_lookup, args, max_depth)
 
@@ -949,7 +976,7 @@ def _walk(
         references.extend(scan_file_detailed(current, scope))
 
         for edge in _edges_in(current, scope):
-            if not _LITERAL_PACKAGE.match(edge.package):
+            if not is_literal_package(edge.package):
                 # Built from a substitution, so there is nothing to look up.
                 edges.append(edge)
                 continue

--- a/package_xml_validation/helpers/find_launch_dependencies.py
+++ b/package_xml_validation/helpers/find_launch_dependencies.py
@@ -21,6 +21,8 @@ import os
 import re
 from typing import Callable, NamedTuple, Optional
 
+import yaml
+
 logger = logging.getLogger(__name__)
 
 
@@ -386,6 +388,13 @@ class Edge(NamedTuple):
     line: int
     resolved: Optional[str]
 
+    by_basename: bool = False
+    """Whether `launch_file` is a bare filename to search the share directory for.
+
+    True only for launch-manager components, which name a file and leave the manager to find
+    it. Everywhere else the path is written out and has to resolve exactly.
+    """
+
 
 class Walk(NamedTuple):
     """What following a seed found.
@@ -433,28 +442,27 @@ _SHARE_PATH = re.compile(
 #: A package name we could look up, as opposed to one assembled at launch time.
 _LITERAL_PACKAGE = re.compile(r"^[A-Za-z0-9_]+$")
 
-#: A launch-manager component: `package:` and then `launch_file:` in the same block.
-_COMPONENT_LAUNCH = re.compile(
-    r"(?m)^[\s\-]*package\s*:\s*['\"]?([A-Za-z0-9_]+)['\"]?"
-    r"(?:.*\n){0,6}?[\s\-]*launch_file\s*:\s*['\"]?([A-Za-z0-9_.\-]+)['\"]?"
-)
-
 _LAUNCH_SUFFIXES = (".launch.py", ".launch.xml", ".launch.yaml", ".launch.yml")
 
 
-def _find_in_share(share: str, relative: str) -> Optional[str]:
+def _find_in_share(
+    share: str, relative: str, by_basename: bool = False
+) -> Optional[str]:
     """The launch file inside a package's share directory, or None.
 
-    The written path first, then the same basename anywhere under the package. The fallback
-    exists for launch-manager components, which name a launch file by bare filename and let
-    the manager find it: `nav2.yaml` says `nav2.launch.yaml`, the file is at
-    `launch/navigation/nav2.launch.yaml`.
+    The written path, and for a bare filename also the same basename anywhere under the
+    package - a launch-manager component says `nav2.launch.yaml` and lets the manager find it
+    at `launch/navigation/nav2.launch.yaml`. First match in sorted order if it occurs twice.
 
-    First match in sorted order when a basename occurs twice.
+    Searching for a written-out path instead would resolve a renamed or uninstalled launch
+    file to a same-named one elsewhere in the package, and report what *that* file names.
     """
     direct = os.path.join(share, relative)
     if os.path.isfile(direct):
         return direct
+
+    if not by_basename:
+        return None
 
     matches = sorted(
         glob.glob(os.path.join(share, "**", os.path.basename(relative)), recursive=True)
@@ -556,18 +564,57 @@ def _edges_in(path: str, scope: Optional[dict] = None) -> list[Edge]:
             # A computed name is kept as written; `_walk` leaves it unresolved.
             edges.append(Edge(package, relative, path, _line_of(text, m.start()), None))
 
-    for m in _COMPONENT_LAUNCH.finditer(text):
-        package, launch_file = m.group(1), m.group(2)
-        edges.append(
-            Edge(
-                package,
-                os.path.join("launch", launch_file),
-                path,
-                _line_of(text, m.start()),
-                None,
-            )
-        )
+    if fmt == FORMAT_YAML:
+        edges.extend(_component_edges(path, text))
 
+    return edges
+
+
+def _component_edges(path: str, text: str) -> list[Edge]:
+    """Launch-manager components in a YAML file: a mapping with `package` and `launch_file`.
+
+    Parsed rather than pattern-matched, so that the two keys have to belong to the *same*
+    mapping. A regex scanning a window of following lines paired a node-only component's
+    `package` with the next component's `launch_file`, which both invented a finding and left
+    the real include unfollowed.
+    """
+    try:
+        root = yaml.compose(text)
+    except yaml.YAMLError:
+        return []
+
+    edges: list[Edge] = []
+
+    def visit(node: "yaml.Node") -> None:
+        if isinstance(node, yaml.SequenceNode):
+            for item in node.value:
+                visit(item)
+            return
+        if not isinstance(node, yaml.MappingNode):
+            return
+
+        scalars = {
+            key.value: (value, key)
+            for key, value in node.value
+            if isinstance(key, yaml.ScalarNode) and isinstance(value, yaml.ScalarNode)
+        }
+        package, launch_file = scalars.get("package"), scalars.get("launch_file")
+        if package and launch_file:
+            edges.append(
+                Edge(
+                    package[0].value,
+                    os.path.join("launch", launch_file[0].value),
+                    path,
+                    package[1].start_mark.line + 1,
+                    None,
+                    by_basename=True,
+                )
+            )
+
+        for _, value in node.value:
+            visit(value)
+
+    visit(root)
     return edges
 
 
@@ -588,11 +635,9 @@ def declared_args(path: str) -> dict:
         return {}
 
     try:
-        import yaml
-
         with open(path, encoding="utf-8") as f:
             document = yaml.safe_load(f) or {}
-    except Exception:
+    except (OSError, yaml.YAMLError):
         # Unparsable: nothing to expand from, so names stay as written and end up unresolved.
         return {}
 
@@ -650,6 +695,21 @@ _SHARE_CALLS = (
 )
 
 
+def _called_name(node: ast.Call) -> str:
+    """The trailing name of a call target: `f(...)` and `a.b.f(...)` both give `f`.
+
+    Qualified calls are common in launch files - `launch.actions.IncludeLaunchDescription`,
+    `ament_index_python.get_package_share_directory` - and matching only `ast.Name` made them
+    invisible: no edge at all, rather than one reported as unreadable.
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
 def _string_of(node: ast.AST) -> Optional[str]:
     return (
         node.value
@@ -679,14 +739,16 @@ def _path_expression(node: ast.AST, bound: dict) -> "Optional[tuple[str, list[st
     if not isinstance(node, ast.Call):
         return None
 
-    if getattr(node.func, "id", "") in _SHARE_CALLS:
+    called = _called_name(node)
+
+    if called in _SHARE_CALLS:
         named = _string_of(node.args[0]) if node.args else None
         return (named, []) if named else None
 
     items: "list[ast.AST]" = []
-    if getattr(node.func, "attr", "") == "join":
+    if called == "join":
         items = list(node.args)
-    elif getattr(node.func, "id", "") == "PathJoinSubstitution":
+    elif called == "PathJoinSubstitution":
         if node.args and isinstance(node.args[0], (ast.List, ast.Tuple)):
             items = list(node.args[0].elts)
 
@@ -760,7 +822,7 @@ def _python_edges(path: str) -> "list[Edge]":
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        if getattr(node.func, "id", "") != "IncludeLaunchDescription":
+        if _called_name(node) != "IncludeLaunchDescription":
             continue
 
         package: Optional[str] = None
@@ -893,7 +955,11 @@ def _walk(
                 continue
 
             share = share_lookup(edge.package)
-            target = _find_in_share(share, edge.launch_file) if share else None
+            target = (
+                _find_in_share(share, edge.launch_file, edge.by_basename)
+                if share
+                else None
+            )
 
             if target is not None and os.path.isfile(target):
                 edges.append(edge._replace(resolved=target))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ package_xml_validation = ["data/*.yaml"]
 
 [project.scripts]
 package-xml-validator = "package_xml_validation.package_xml_validator:main"
+check-launch-tree = "package_xml_validation.check_launch_tree:main"
 
 [tool.mypy]
 python_version = "3.9"

--- a/tests/examples/launch_examples/python_annotation_and_literal.py
+++ b/tests/examples/launch_examples/python_annotation_and_literal.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
 """A Python file that references no packages at all.
 
-Every `pkg:` below is Python syntax or data - an annotation, a dict key, a string. None of
-them is a YAML mapping key, and reading them as one produced packages named `str` and `robot`.
+Every `pkg` and `package` below is Python syntax or data - an annotation, a dict key, a string,
+an assignment. None is a YAML mapping key or a TOML entry, and each is written in the position
+that only the *format* of the pattern rules out: at the start of a line, where anchoring alone
+would let it through.
 """
 
 from typing import Any
+
+#: A module-level annotated assignment. `pkg:` starts the line, so only the fact that this file
+#: is Python keeps it from reading as a YAML mapping key.
+pkg: str = "hello"
+
+#: `package = "x"` is the better_launch TOML form, and an ordinary assignment in Python.
+package = "sneaky_toml_form"
 
 
 def resolve(pkg: str, timeout: float, options: Any = None) -> str:

--- a/tests/examples/launch_examples/python_annotation_and_literal.py
+++ b/tests/examples/launch_examples/python_annotation_and_literal.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""A Python file that references no packages at all.
+
+Every `pkg:` below is Python syntax or data - an annotation, a dict key, a string. None of
+them is a YAML mapping key, and reading them as one produced packages named `str` and `robot`.
+"""
+
+from typing import Any
+
+
+def resolve(pkg: str, timeout: float, options: Any = None) -> str:
+    """`pkg: str` is a type annotation."""
+    return pkg
+
+
+LAUNCH_SPEC = {"launch_file": "pkg:robot.launch.yaml"}
+
+ANOTHER = "package: not_a_reference_either"

--- a/tests/examples/launch_examples/yaml_keys_ending_in_pkg.launch.yml
+++ b/tests/examples/launch_examples/yaml_keys_ending_in_pkg.launch.yml
@@ -1,0 +1,10 @@
+launch:
+  - node:
+      pkg: real_package
+      name: a_node
+  - node:
+      mypkg: not_a_package
+      subpkg: also_not_a_package
+      name: another_node
+  - node:
+      pkg: "quoted_package"

--- a/tests/examples/launch_examples/yaml_sequence_item_package.yaml
+++ b/tests/examples/launch_examples/yaml_sequence_item_package.yaml
@@ -1,0 +1,6 @@
+# A hector launch component: the key is the first thing on the line after the sequence dash.
+components:
+  - package: sequence_item_package
+    executable: something
+  - package: another_sequence_package
+    executable: something_else

--- a/tests/test_check_launch_tree.py
+++ b/tests/test_check_launch_tree.py
@@ -5,7 +5,12 @@ import tempfile
 import unittest
 from unittest import mock
 
-from package_xml_validation.check_launch_tree import check, main, workspace_is_available
+from package_xml_validation.check_launch_tree import (
+    check,
+    main,
+    package_dirs_under,
+    workspace_is_available,
+)
 
 
 class LaunchTreeTestCase(unittest.TestCase):
@@ -28,12 +33,18 @@ class LaunchTreeTestCase(unittest.TestCase):
             f.write(text)
         return path
 
-    def package(self, name, relative, text):
-        path = os.path.join(self.root, name, relative)
+    def package(self, name, relative, text, under=""):
+        """A source package: a `package.xml` plus one file, at `<root>/<under>/<name>`."""
+        directory = os.path.join(self.root, under, name)
+        path = os.path.join(directory, relative)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             f.write(text)
-        return os.path.join(self.root, name)
+        with open(os.path.join(directory, "package.xml"), "w", encoding="utf-8") as f:
+            f.write(
+                f'<package format="3"><name>{os.path.basename(name)}</name></package>'
+            )
+        return directory
 
 
 class TestWhatItFinds(LaunchTreeTestCase):
@@ -107,6 +118,41 @@ class TestWhatItFinds(LaunchTreeTestCase):
 
         self.assertEqual([], missing)
         self.assertEqual([], dead)
+
+
+class TestFindingThePackagesToCheck(LaunchTreeTestCase):
+    """The hook is handed a repository root, not a package directory."""
+
+    def test_a_repository_root_finds_the_packages_below_it(self):
+        """`check` works one package at a time, so nothing under `src/` was ever read and the
+        hook passed silently on every multi-package repository."""
+        self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: absent_driver\n",
+            under="src",
+        )
+
+        found = package_dirs_under([self.root])
+
+        self.assertEqual([os.path.join(self.root, "src", "app")], found)
+
+    def test_it_fails_on_a_finding_below_the_root(self):
+        self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: absent_driver\n",
+            under="src",
+        )
+
+        with mock.patch("sys.argv", ["check-launch-tree", "--error", self.root]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+        self.assertEqual(1, exit.exception.code)
+
+    def test_a_directory_with_no_packages_says_so(self):
+        with mock.patch("sys.argv", ["check-launch-tree", "--error", self.root]):
+            main()  # must not raise SystemExit
 
 
 class TestItNeedsAWorkspaceAndSaysSo(LaunchTreeTestCase):

--- a/tests/test_check_launch_tree.py
+++ b/tests/test_check_launch_tree.py
@@ -1,11 +1,14 @@
 """The launch-tree check: does everything this tree reaches exist here?"""
 
+import contextlib
+import io
 import os
 import tempfile
 import unittest
 from unittest import mock
 
 from package_xml_validation.check_launch_tree import (
+    LISTED_UNREAD,
     check,
     main,
     package_dirs_under,
@@ -28,6 +31,14 @@ class LaunchTreeTestCase(unittest.TestCase):
 
     def install(self, package, relative, text=""):
         path = os.path.join(self.prefix, "share", package, relative)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def write_into(self, directory, relative, text):
+        """Another file in a package that already exists."""
+        path = os.path.join(directory, relative)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             f.write(text)
@@ -105,6 +116,23 @@ class TestWhatItFinds(LaunchTreeTestCase):
         _, missing, _ = check(pkg)
 
         self.assertEqual(["absent_from_everywhere"], missing)
+
+    def test_a_name_still_holding_a_substitution_is_neither(self):
+        """It names no package, so it is neither a missing package nor a package that failed
+        to ship a file - it is an include nobody could follow, and was reported as
+        `$(var undeclared)_sim does not ship ...`."""
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - include:\n"
+            '      file: "$(find-pkg-share $(var undeclared)_sim)/launch/x.launch.yaml"\n',
+        )
+
+        walk, missing, dead = check(pkg)
+
+        self.assertEqual([], missing)
+        self.assertEqual([], dead)
+        self.assertEqual(1, len(walk.unresolved))
 
     def test_a_healthy_package_reports_nothing(self):
         self.install("driver", "launch/driver.launch.yaml", "launch: []\n")
@@ -200,6 +228,66 @@ class TestHowItFails(LaunchTreeTestCase):
             main()
 
 
+class TestWhatItPrints(LaunchTreeTestCase):
+    """The report is the whole product of this tool, so its lines are worth asserting."""
+
+    def report_for(self, package_dir):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            with mock.patch("sys.argv", ["check-launch-tree", package_dir]):
+                main()
+        return out.getvalue()
+
+    def test_a_dead_include_names_the_package_the_file_and_the_line(self):
+        self.install("driver", "launch/something_else.launch.yaml", "launch: []\n")
+        pkg = self.package(
+            "app",
+            "launch_manager_components/broken.yaml",
+            "launch:\n  package: driver\n  launch_file: not_shipped.launch.yaml\n",
+        )
+
+        report = self.report_for(pkg)
+
+        self.assertIn("driver does not ship launch/not_shipped.launch.yaml", report)
+        self.assertIn("launch_manager_components/broken.yaml:2", report)
+
+    def test_a_file_outside_the_package_is_named_absolutely(self):
+        """The reference that breaks a tree is often in another package entirely, where a
+        relative path would be a chain of `../..`."""
+        self.install(
+            "aggregator",
+            "launch/pipeline.launch.yaml",
+            "launch:\n  - node:\n      pkg: absent_from_everywhere\n",
+        )
+        pkg = self.package(
+            "app",
+            "launch_manager_components/detection.yaml",
+            "launch:\n  package: aggregator\n  launch_file: pipeline.launch.yaml\n",
+        )
+
+        report = self.report_for(pkg)
+
+        self.assertIn("absent_from_everywhere is not installed", report)
+        self.assertIn(
+            os.path.join(self.prefix, "share", "aggregator", "launch"), report
+        )
+
+    def test_unfollowable_includes_beyond_the_listed_few_are_counted(self):
+        """A truncated list that does not say it is truncated reads as the whole story."""
+        lines = ["launch:"]
+        for i in range(LISTED_UNREAD + 3):
+            lines.append("  - include:")
+            lines.append(
+                f'      file: "$(find-pkg-share $(var undeclared)_{i})/launch/x.launch.yaml"'
+            )
+        pkg = self.package("app", "launch/app.launch.yaml", "\n".join(lines) + "\n")
+
+        report = self.report_for(pkg)
+
+        self.assertIn(f"{LISTED_UNREAD + 3} include(s) could not be followed", report)
+        self.assertIn("... and 3 more", report)
+
+
 class TestLaunchArguments(LaunchTreeTestCase):
     """A tree whose shape depends on an argument is only followed once a value is known."""
 
@@ -237,3 +325,50 @@ class TestLaunchArguments(LaunchTreeTestCase):
 
         self.assertEqual([], walk.unresolved)
         self.assertIn("telemax_only", missing)
+
+    def test_the_cli_passes_arg_name_value_through(self):
+        """`--arg robot=telemax` reaches the walk, so the include resolves and the package
+        behind it is found missing - which fails the run."""
+        with mock.patch(
+            "sys.argv",
+            ["check-launch-tree", "--error", "--arg", "robot=telemax", self.pkg],
+        ):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+        self.assertEqual(1, exit.exception.code)
+
+
+class TestOneFindingIsReportedOnce(LaunchTreeTestCase):
+    """Seed directories share one walk, so a file both reach is read once.
+
+    Walking each directory separately re-read everything reachable from more than one of them,
+    so a finding inside a shared launch file was reported once per directory that led to it.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.install("driver", "launch/a_different_file.launch.yaml", "launch: []\n")
+        self.install(
+            "common",
+            "launch/shared.launch.yaml",
+            "launch:\n  - include:\n"
+            '      file: "$(find-pkg-share driver)/launch/gone.launch.yaml"\n',
+        )
+
+        reaches_shared = (
+            "launch:\n  - include:\n"
+            '      file: "$(find-pkg-share common)/launch/shared.launch.yaml"\n'
+        )
+        self.pkg = self.package("app", "launch/a.launch.yaml", reaches_shared)
+        self.write_into(self.pkg, "launch_manager_components/b.yaml", reaches_shared)
+
+    def test_the_shared_file_is_read_once(self):
+        walk, _, _ = check(self.pkg)
+
+        read_shared = [f for f in walk.visited if f.endswith("shared.launch.yaml")]
+        self.assertEqual(1, len(read_shared))
+
+    def test_its_dead_include_is_reported_once(self):
+        _, _, dead = check(self.pkg)
+
+        self.assertEqual(1, len(dead))

--- a/tests/test_check_launch_tree.py
+++ b/tests/test_check_launch_tree.py
@@ -1,4 +1,4 @@
-"""The launch-tree check: does everything this tree reaches exist here?"""
+"""The launch-tree check: does everything this tree reaches exist, and is it declared?"""
 
 import contextlib
 import io
@@ -8,12 +8,29 @@ import unittest
 from unittest import mock
 
 from package_xml_validation.check_launch_tree import (
+    DEAD_INCLUDE,
+    FATAL,
     LISTED_UNREAD,
+    NOT_INSTALLED,
+    UNDECLARED,
+    WARNING,
+    Scope,
     check,
     main,
     package_dirs_under,
     workspace_is_available,
 )
+
+
+def manifest(name, deps=(), ignore=()):
+    body = "".join(f"<exec_depend>{one}</exec_depend>" for one in deps)
+    if ignore:
+        body += f"<!-- validator:ignore {' '.join(ignore)} -->"
+    return f'<package format="3"><name>{name}</name>{body}</package>'
+
+
+def of_kind(findings, kind):
+    return [one for one in findings if one.kind == kind]
 
 
 class LaunchTreeTestCase(unittest.TestCase):
@@ -29,48 +46,83 @@ class LaunchTreeTestCase(unittest.TestCase):
         self._env.stop()
         self._tmp.cleanup()
 
-    def install(self, package, relative, text=""):
-        path = os.path.join(self.prefix, "share", package, relative)
+    def write(self, path, text):
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             f.write(text)
         return path
+
+    def install(self, package, relative, text="", deps=()):
+        """A package in the install space, manifest included - the same as a real one."""
+        share = os.path.join(self.prefix, "share", package)
+        self.write(os.path.join(share, "package.xml"), manifest(package, deps))
+        return self.write(os.path.join(share, relative), text)
 
     def write_into(self, directory, relative, text):
         """Another file in a package that already exists."""
-        path = os.path.join(directory, relative)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(text)
-        return path
+        return self.write(os.path.join(directory, relative), text)
 
-    def package(self, name, relative, text, under=""):
+    def package(self, name, relative, text, under="", deps=(), ignore=()):
         """A source package: a `package.xml` plus one file, at `<root>/<under>/<name>`."""
         directory = os.path.join(self.root, under, name)
-        path = os.path.join(directory, relative)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(text)
-        with open(os.path.join(directory, "package.xml"), "w", encoding="utf-8") as f:
-            f.write(
-                f'<package format="3"><name>{os.path.basename(name)}</name></package>'
-            )
+        self.write(os.path.join(directory, relative), text)
+        self.write(
+            os.path.join(directory, "package.xml"),
+            manifest(os.path.basename(name), deps, ignore),
+        )
         return directory
 
 
 class TestWhatItFinds(LaunchTreeTestCase):
-    def test_a_package_that_is_not_installed(self):
-        """The launch file names it and nothing here provides it."""
+    def test_a_reference_the_manifest_does_not_declare(self):
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: some_driver\n",
+        )
+
+        _, findings = check(pkg)
+
+        self.assertEqual(1, len(of_kind(findings, UNDECLARED)))
+        self.assertEqual("some_driver", findings[0].package)
+        self.assertEqual(FATAL, findings[0].severity)
+
+    def test_a_declared_reference_is_not_a_manifest_finding(self):
+        """Still a warning that it is not installed - that part is the workspace's business."""
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: some_driver\n",
+            deps=["some_driver"],
+        )
+
+        _, findings = check(pkg)
+
+        self.assertEqual([], of_kind(findings, UNDECLARED))
+        self.assertEqual([WARNING], [one.severity for one in findings])
+
+    def test_a_package_naming_itself_is_not_a_finding(self):
+        pkg = self.package(
+            "app", "launch/app.launch.yaml", "launch:\n  - node:\n      pkg: app\n"
+        )
+
+        _, findings = check(pkg)
+
+        self.assertEqual([], findings)
+
+    def test_a_package_that_is_not_installed_only_warns(self):
+        """A CI runner may simply not have built it, so nothing in the checkout is wrong."""
         pkg = self.package(
             "app",
             "launch/app.launch.yaml",
             "launch:\n  - node:\n      pkg: absent_driver\n",
+            deps=["absent_driver"],
         )
 
-        _, missing, dead = check(pkg)
+        _, findings = check(pkg)
 
-        self.assertEqual(["absent_driver"], missing)
-        self.assertEqual([], dead)
+        self.assertEqual(1, len(of_kind(findings, NOT_INSTALLED)))
+        self.assertEqual(WARNING, findings[0].severity)
 
     def test_an_include_that_leads_nowhere(self):
         """A different fault: the package is there, the launch file it names is not."""
@@ -79,13 +131,15 @@ class TestWhatItFinds(LaunchTreeTestCase):
             "app",
             "launch_manager_components/broken.yaml",
             "launch:\n  package: driver\n  launch_file: not_shipped.launch.yaml\n",
+            deps=["driver"],
         )
 
-        _, missing, dead = check(pkg)
+        _, findings = check(pkg)
 
-        self.assertEqual([], missing)
+        dead = of_kind(findings, DEAD_INCLUDE)
         self.assertEqual(1, len(dead))
-        self.assertIn("not_shipped.launch.yaml", dead[0].launch_file)
+        self.assertEqual("not_shipped.launch.yaml", dead[0].launch_file)
+        self.assertEqual(FATAL, dead[0].severity)
 
     def test_a_missing_package_is_not_also_reported_as_a_dead_include(self):
         """One fault, one line: the include fails *because* the package is absent."""
@@ -93,12 +147,12 @@ class TestWhatItFinds(LaunchTreeTestCase):
             "app",
             "launch_manager_components/one.yaml",
             "launch:\n  package: absent\n  launch_file: x.launch.yaml\n",
+            deps=["absent"],
         )
 
-        _, missing, dead = check(pkg)
+        _, findings = check(pkg)
 
-        self.assertEqual(["absent"], missing)
-        self.assertEqual([], dead)
+        self.assertEqual([NOT_INSTALLED], [one.kind for one in findings])
 
     def test_it_follows_into_other_packages(self):
         """The reference that breaks a tree is often not in the repository being committed to."""
@@ -111,16 +165,16 @@ class TestWhatItFinds(LaunchTreeTestCase):
             "app",
             "launch_manager_components/detection.yaml",
             "launch:\n  package: aggregator\n  launch_file: pipeline.launch.yaml\n",
+            deps=["aggregator"],
         )
 
-        _, missing, _ = check(pkg)
+        _, findings = check(pkg)
 
-        self.assertEqual(["absent_from_everywhere"], missing)
+        self.assertIn("absent_from_everywhere", [one.package for one in findings])
 
     def test_a_name_still_holding_a_substitution_is_neither(self):
         """It names no package, so it is neither a missing package nor a package that failed
-        to ship a file - it is an include nobody could follow, and was reported as
-        `$(var undeclared)_sim does not ship ...`."""
+        to ship a file - it is an include nobody could follow."""
         pkg = self.package(
             "app",
             "launch/app.launch.yaml",
@@ -128,10 +182,9 @@ class TestWhatItFinds(LaunchTreeTestCase):
             '      file: "$(find-pkg-share $(var undeclared)_sim)/launch/x.launch.yaml"\n',
         )
 
-        walk, missing, dead = check(pkg)
+        walk, findings = check(pkg)
 
-        self.assertEqual([], missing)
-        self.assertEqual([], dead)
+        self.assertEqual([], findings)
         self.assertEqual(1, len(walk.unresolved))
 
     def test_a_healthy_package_reports_nothing(self):
@@ -140,20 +193,183 @@ class TestWhatItFinds(LaunchTreeTestCase):
             "app",
             "launch_manager_components/fine.yaml",
             "launch:\n  package: driver\n  launch_file: driver.launch.yaml\n",
+            deps=["driver"],
         )
 
-        _, missing, dead = check(pkg)
+        _, findings = check(pkg)
 
-        self.assertEqual([], missing)
-        self.assertEqual([], dead)
+        self.assertEqual([], findings)
+
+    def test_a_config_key_merely_ending_in_package_is_not_a_reference(self):
+        """`launch/` holds parameter files as well as launch files, and both are scanned. The
+        anchored key is what keeps `plugin_package:` and friends out of a fatal finding."""
+        pkg = self.package(
+            "app",
+            "launch/params.yaml",
+            "some_node:\n  ros__parameters:\n    plugin_package: not_a_dependency\n",
+        )
+
+        _, findings = check(pkg)
+
+        self.assertEqual([], findings)
+
+    def test_a_bare_package_key_in_a_config_file_is_read_as_a_reference(self):
+        """A known limitation, written down rather than implied away: nothing distinguishes a
+        parameter file under `launch/` from a component definition, so a `package:` key in one
+        is a fatal finding. No file in hector/src is shaped this way; if one appears, the fix
+        is `<!-- validator:ignore -->` or `--ignore`."""
+        pkg = self.package(
+            "app",
+            "launch/params.yaml",
+            "some_node:\n  ros__parameters:\n    package: not_a_dependency\n",
+        )
+
+        _, findings = check(pkg)
+
+        undeclared = of_kind(findings, UNDECLARED)
+        self.assertEqual(["not_a_dependency"], [one.package for one in undeclared])
+        self.assertEqual(FATAL, undeclared[0].severity)
+
+    def test_a_file_with_no_manifest_above_it_is_not_graded(self):
+        """There is nothing to hold responsible, so the reference is left alone rather than
+        blamed on the package that reached it."""
+        orphan = os.path.join(self.prefix, "share", "orphan")
+        self.write(
+            os.path.join(orphan, "launch", "x.launch.yaml"),
+            "launch:\n  - node:\n      pkg: named_by_an_orphan\n",
+        )
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share orphan)/launch/x.launch.yaml"\n',
+            deps=["orphan"],
+        )
+
+        _, findings = check(pkg)
+
+        self.assertEqual([], of_kind(findings, UNDECLARED))
+        self.assertNotIn(FATAL, [one.severity for one in findings])
+
+    def test_a_package_named_twice_is_one_finding(self):
+        """A manifest entry is missing once, however many nodes noticed."""
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n"
+            "  - node:\n      pkg: some_driver\n"
+            "  - node:\n      pkg: some_driver\n",
+        )
+
+        _, findings = check(pkg)
+
+        self.assertEqual(1, len(of_kind(findings, UNDECLARED)))
+
+    def test_a_dead_include_with_no_manifest_above_it_only_warns(self):
+        """Same rule as everywhere else: no manifest to hold responsible, no failure."""
+        self.write(
+            os.path.join(self.prefix, "share", "orphan", "launch", "x.launch.yaml"),
+            'launch:\n  - include:\n      file: "$(find-pkg-share driver)/launch/gone.launch.yaml"\n',
+        )
+        self.install("driver", "launch/a_different_file.launch.yaml", "launch: []\n")
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share orphan)/launch/x.launch.yaml"\n',
+            deps=["orphan"],
+        )
+
+        _, findings = check(pkg)
+
+        dead = of_kind(findings, DEAD_INCLUDE)
+        self.assertEqual(1, len(dead))
+        self.assertEqual(WARNING, dead[0].severity)
+
+    def test_a_manifest_that_does_not_parse_only_warns(self):
+        """Whether it is valid XML at all is `format-package-xml`'s question, and it fails the
+        commit on its own. This one has nothing to grade against, so it does not pile on."""
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: some_driver\n",
+        )
+        self.write(os.path.join(pkg, "package.xml"), "<package><name>app</name>")
+
+        _, findings = check(pkg)
+
+        self.assertNotIn(FATAL, [one.severity for one in findings])
+
+    def test_an_ignored_dependency_is_left_out(self):
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: some_driver\n",
+            ignore=["some_driver"],
+        )
+
+        _, findings = check(pkg)
+
+        self.assertEqual([], findings)
+
+
+class TestWhoIsHeldResponsible(LaunchTreeTestCase):
+    """A finding is only fatal when the package that owns the offending file is fixable."""
+
+    def reaching_an_installed_package(self, **package_kwargs):
+        self.install(
+            "aggregator",
+            "launch/pipeline.launch.yaml",
+            "launch:\n  - node:\n      pkg: undeclared_by_aggregator\n",
+        )
+        return self.package(
+            "app",
+            "launch_manager_components/detection.yaml",
+            "launch:\n  package: aggregator\n  launch_file: pipeline.launch.yaml\n",
+            deps=["aggregator"],
+            **package_kwargs,
+        )
+
+    def test_a_binary_only_install_only_warns(self):
+        """Nobody committing here can edit /opt, so failing on it would just block the repo."""
+        pkg = self.reaching_an_installed_package()
+
+        _, findings = check(pkg)
+
+        undeclared = of_kind(findings, UNDECLARED)
+        self.assertEqual(1, len(undeclared))
+        self.assertEqual(WARNING, undeclared[0].severity)
+
+    def test_fatal_under_makes_an_install_prefix_ours(self):
+        """The CI shape: the pipeline installs the packages itself, so they are its to fix."""
+        pkg = self.reaching_an_installed_package()
+        scope = Scope.of([pkg], fatal_under=(self.prefix,))
+
+        _, findings = check(pkg, scope=scope)
+
+        self.assertEqual(FATAL, of_kind(findings, UNDECLARED)[0].severity)
+
+    def test_the_checkouts_manifest_wins_over_the_installed_copy(self):
+        """Includes resolve through find-pkg-share, so the file read is the installed one. The
+        manifest to grade against is still the one in the checkout."""
+        pkg = self.reaching_an_installed_package()
+        source = self.package(
+            "aggregator",
+            "launch/pipeline.launch.yaml",
+            "launch:\n  - node:\n      pkg: undeclared_by_aggregator\n",
+        )
+        scope = Scope.of([self.root])
+
+        _, findings = check(pkg, scope=scope)
+
+        undeclared = of_kind(findings, UNDECLARED)
+        self.assertEqual(1, len(undeclared))
+        self.assertEqual(os.path.join(source, "package.xml"), undeclared[0].owner)
+        self.assertEqual(FATAL, undeclared[0].severity)
 
 
 class TestFindingThePackagesToCheck(LaunchTreeTestCase):
     """The hook is handed a repository root, not a package directory."""
 
     def test_a_repository_root_finds_the_packages_below_it(self):
-        """`check` works one package at a time, so nothing under `src/` was ever read and the
-        hook passed silently on every multi-package repository."""
         self.package(
             "app",
             "launch/app.launch.yaml",
@@ -173,83 +389,142 @@ class TestFindingThePackagesToCheck(LaunchTreeTestCase):
             under="src",
         )
 
-        with mock.patch("sys.argv", ["check-launch-tree", "--error", self.root]):
+        with mock.patch("sys.argv", ["check-launch-tree", self.root]):
             with self.assertRaises(SystemExit) as exit:
                 main()
         self.assertEqual(1, exit.exception.code)
 
     def test_a_directory_with_no_packages_says_so(self):
-        with mock.patch("sys.argv", ["check-launch-tree", "--error", self.root]):
+        with mock.patch("sys.argv", ["check-launch-tree", self.root]):
             main()  # must not raise SystemExit
 
 
-class TestItNeedsAWorkspaceAndSaysSo(LaunchTreeTestCase):
-    """Without AMENT_PREFIX_PATH there is nothing to resolve against, so the check skips."""
-
-    def test_it_reports_that_it_could_not_look(self):
-        with mock.patch.dict(os.environ, {"AMENT_PREFIX_PATH": ""}):
-            self.assertFalse(workspace_is_available())
-
-    def test_it_does_not_fail_when_there_is_nothing_to_resolve_against(self):
-        """Not even with --error: every package would read as missing."""
-        pkg = self.package(
-            "app", "launch/app.launch.yaml", "launch:\n  - node:\n      pkg: anything\n"
-        )
-
-        with mock.patch.dict(os.environ, {"AMENT_PREFIX_PATH": ""}):
-            with mock.patch("sys.argv", ["check-launch-tree", "--error", pkg]):
-                main()  # must not raise SystemExit
-
-
-class TestHowItFails(LaunchTreeTestCase):
-    """Warns by default so it can be introduced to a repository that already has findings."""
+class TestWithoutAWorkspace(LaunchTreeTestCase):
+    """AMENT_PREFIX_PATH decides how far the walk reaches, not whether it runs."""
 
     def setUp(self):
         super().setUp()
         self.pkg = self.package(
             "app",
             "launch/app.launch.yaml",
-            "launch:\n  - node:\n      pkg: absent_driver\n",
+            "launch:\n  - node:\n      pkg: some_driver\n",
+        )
+        self.empty = mock.patch.dict(os.environ, {"AMENT_PREFIX_PATH": ""})
+
+    def test_it_knows_when_there_is_nothing_to_resolve_against(self):
+        with self.empty:
+            self.assertFalse(workspace_is_available())
+
+    def test_nothing_is_reported_as_missing(self):
+        """Every package would read as missing, which says nothing about the checkout."""
+        with self.empty:
+            _, findings = check(self.pkg)
+
+        self.assertEqual([], of_kind(findings, NOT_INSTALLED))
+
+    def test_the_manifest_check_still_runs(self):
+        """It never needed a workspace, and it is the reason this can run in CI at all."""
+        with self.empty:
+            with mock.patch("sys.argv", ["check-launch-tree", self.pkg]):
+                with self.assertRaises(SystemExit) as exit:
+                    main()
+        self.assertEqual(1, exit.exception.code)
+
+
+class TestHowItFails(LaunchTreeTestCase):
+    def setUp(self):
+        super().setUp()
+        self.pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: some_driver\n",
         )
 
-    def test_findings_alone_do_not_fail_the_hook(self):
+    def test_a_manifest_finding_fails_the_run(self):
         with mock.patch("sys.argv", ["check-launch-tree", self.pkg]):
-            main()
-
-    def test_error_makes_findings_fatal(self):
-        with mock.patch("sys.argv", ["check-launch-tree", "--error", self.pkg]):
             with self.assertRaises(SystemExit) as exit:
                 main()
         self.assertEqual(1, exit.exception.code)
 
-    def test_a_clean_package_passes_with_error(self):
+    def test_warn_only_reports_the_same_thing_and_passes(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            with mock.patch("sys.argv", ["check-launch-tree", "--warn-only", self.pkg]):
+                main()  # must not raise SystemExit
+
+        self.assertIn("some_driver is not declared", out.getvalue())
+
+    def test_ignore_drops_the_finding_altogether(self):
+        with mock.patch(
+            "sys.argv", ["check-launch-tree", "--ignore", "some_driver", self.pkg]
+        ):
+            main()  # must not raise SystemExit
+
+    def test_a_clean_package_passes(self):
         clean = self.package("clean", "launch/x.launch.yaml", "launch: []\n")
-        with mock.patch("sys.argv", ["check-launch-tree", "--error", clean]):
+        with mock.patch("sys.argv", ["check-launch-tree", clean]):
             main()
 
 
 class TestWhatItPrints(LaunchTreeTestCase):
     """The report is the whole product of this tool, so its lines are worth asserting."""
 
-    def report_for(self, package_dir):
+    def report_for(self, package_dir, *argv):
         out = io.StringIO()
         with contextlib.redirect_stdout(out):
-            with mock.patch("sys.argv", ["check-launch-tree", package_dir]):
-                main()
+            with mock.patch("sys.argv", ["check-launch-tree", *argv, package_dir]):
+                with contextlib.suppress(SystemExit):
+                    main()
         return out.getvalue()
 
-    def test_a_dead_include_names_the_package_the_file_and_the_line(self):
+    def test_a_clean_package_prints_nothing(self):
+        """`verbose: true` shows everything this prints, so a clean run has to be silent."""
+        clean = self.package("clean", "launch/x.launch.yaml", "launch: []\n")
+
+        self.assertEqual("", self.report_for(clean))
+
+    def test_a_finding_carries_its_severity_the_file_and_the_line(self):
         self.install("driver", "launch/something_else.launch.yaml", "launch: []\n")
         pkg = self.package(
             "app",
             "launch_manager_components/broken.yaml",
             "launch:\n  package: driver\n  launch_file: not_shipped.launch.yaml\n",
+            deps=["driver"],
         )
 
         report = self.report_for(pkg)
 
-        self.assertIn("driver does not ship launch/not_shipped.launch.yaml", report)
+        self.assertIn("error", report)
+        self.assertIn("driver does not ship not_shipped.launch.yaml", report)
         self.assertIn("launch_manager_components/broken.yaml:2", report)
+
+    def test_one_package_that_is_both_undeclared_and_absent_is_one_finding(self):
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: absent_driver\n",
+        )
+
+        report = self.report_for(pkg)
+
+        self.assertIn(
+            "is not declared in package.xml (and is not installed here)", report
+        )
+        self.assertNotIn("is not installed in this workspace", report)
+
+    def test_a_package_that_is_only_absent_says_so_and_passes(self):
+        """The line a CI runner without a built workspace will see most of."""
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: absent_driver\n",
+            deps=["absent_driver"],
+        )
+
+        report = self.report_for(pkg)
+
+        self.assertIn("warning", report)
+        self.assertIn("absent_driver is not installed in this workspace", report)
 
     def test_a_file_outside_the_package_is_named_absolutely(self):
         """The reference that breaks a tree is often in another package entirely, where a
@@ -263,11 +538,11 @@ class TestWhatItPrints(LaunchTreeTestCase):
             "app",
             "launch_manager_components/detection.yaml",
             "launch:\n  package: aggregator\n  launch_file: pipeline.launch.yaml\n",
+            deps=["aggregator"],
         )
 
         report = self.report_for(pkg)
 
-        self.assertIn("absent_from_everywhere is not installed", report)
         self.assertIn(
             os.path.join(self.prefix, "share", "aggregator", "launch"), report
         )
@@ -308,30 +583,36 @@ class TestLaunchArguments(LaunchTreeTestCase):
             "launch/spawn.launch.yaml",
             "launch:\n  - node:\n      pkg: telemax_only\n",
         )
-        self.pkg = self.package("scenario", "launch/robot.launch.yaml", self.SEED)
+        self.pkg = self.package(
+            "scenario", "launch/robot.launch.yaml", self.SEED, deps=["telemax_sim"]
+        )
 
     def test_the_default_leads_somewhere_that_is_not_installed(self):
         """`athena_sim` is not here, so the include is reported rather than guessed at."""
-        walk, missing, _ = check(self.pkg)
+        walk, _ = check(self.pkg)
 
         self.assertEqual(1, len(walk.unresolved))
         self.assertIn("athena_sim", walk.unresolved[0].package)
-        self.assertNotIn("telemax_only", missing)
 
     def test_a_supplied_value_follows_the_other_branch(self):
         """With robot=telemax the include resolves and what the file behind it names is
-        checked."""
-        walk, missing, _ = check(self.pkg, args={"robot": "telemax"})
+        checked - against telemax_sim's own manifest."""
+        walk, findings = check(self.pkg, args={"robot": "telemax"})
 
         self.assertEqual([], walk.unresolved)
-        self.assertIn("telemax_only", missing)
+        self.assertIn("telemax_only", [one.package for one in findings])
 
     def test_the_cli_passes_arg_name_value_through(self):
-        """`--arg robot=telemax` reaches the walk, so the include resolves and the package
-        behind it is found missing - which fails the run."""
         with mock.patch(
             "sys.argv",
-            ["check-launch-tree", "--error", "--arg", "robot=telemax", self.pkg],
+            [
+                "check-launch-tree",
+                "--fatal-under",
+                self.prefix,
+                "--arg",
+                "robot=telemax",
+                self.pkg,
+            ],
         ):
             with self.assertRaises(SystemExit) as exit:
                 main()
@@ -339,11 +620,7 @@ class TestLaunchArguments(LaunchTreeTestCase):
 
 
 class TestOneFindingIsReportedOnce(LaunchTreeTestCase):
-    """Seed directories share one walk, so a file both reach is read once.
-
-    Walking each directory separately re-read everything reachable from more than one of them,
-    so a finding inside a shared launch file was reported once per directory that led to it.
-    """
+    """Seed directories share one walk, so a file both reach is read once."""
 
     def setUp(self):
         super().setUp()
@@ -353,22 +630,25 @@ class TestOneFindingIsReportedOnce(LaunchTreeTestCase):
             "launch/shared.launch.yaml",
             "launch:\n  - include:\n"
             '      file: "$(find-pkg-share driver)/launch/gone.launch.yaml"\n',
+            deps=["driver"],
         )
 
         reaches_shared = (
             "launch:\n  - include:\n"
             '      file: "$(find-pkg-share common)/launch/shared.launch.yaml"\n'
         )
-        self.pkg = self.package("app", "launch/a.launch.yaml", reaches_shared)
+        self.pkg = self.package(
+            "app", "launch/a.launch.yaml", reaches_shared, deps=["common"]
+        )
         self.write_into(self.pkg, "launch_manager_components/b.yaml", reaches_shared)
 
     def test_the_shared_file_is_read_once(self):
-        walk, _, _ = check(self.pkg)
+        walk, _ = check(self.pkg)
 
         read_shared = [f for f in walk.visited if f.endswith("shared.launch.yaml")]
         self.assertEqual(1, len(read_shared))
 
     def test_its_dead_include_is_reported_once(self):
-        _, _, dead = check(self.pkg)
+        _, findings = check(self.pkg)
 
-        self.assertEqual(1, len(dead))
+        self.assertEqual(1, len(of_kind(findings, DEAD_INCLUDE)))

--- a/tests/test_check_launch_tree.py
+++ b/tests/test_check_launch_tree.py
@@ -347,6 +347,98 @@ class TestWhoIsHeldResponsible(LaunchTreeTestCase):
 
         self.assertEqual(FATAL, of_kind(findings, UNDECLARED)[0].severity)
 
+    def test_fatal_under_reaches_a_source_tree_too(self):
+        """The flag indexes what it points at rather than only prefix-matching the manifest a
+        finding landed on, so it works for a source checkout outside the scanned path. Without
+        that, the owner stays the installed copy and the prefix never matches."""
+        self.install(
+            "driver",
+            "launch/d.launch.yaml",
+            "launch:\n  - node:\n      pkg: undeclared_by_driver\n",
+        )
+        source = self.package(
+            "driver",
+            "launch/d.launch.yaml",
+            "launch:\n  - node:\n      pkg: undeclared_by_driver\n",
+            under="elsewhere",
+        )
+        app = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share driver)/launch/d.launch.yaml"\n',
+            deps=["driver"],
+        )
+        elsewhere = os.path.join(self.root, "elsewhere")
+
+        _, findings = check(app, scope=Scope.of([app], fatal_under=(elsewhere,)))
+
+        undeclared = of_kind(findings, UNDECLARED)
+        self.assertEqual(1, len(undeclared))
+        self.assertEqual(FATAL, undeclared[0].severity)
+        self.assertEqual(os.path.join(source, "package.xml"), undeclared[0].owner)
+
+    def test_a_sibling_repository_in_the_same_workspace_is_ours(self):
+        """One repository per package is the normal ROS layout, so "the checkout" is a single
+        package and every sibling would otherwise be someone else's problem. Only `src/app` is
+        passed here; `src/driver` is found by walking up to the workspace root."""
+        self.install(
+            "driver",
+            "launch/d.launch.yaml",
+            "launch:\n  - node:\n      pkg: undeclared_by_driver\n",
+        )
+        driver = self.package(
+            "driver",
+            "launch/d.launch.yaml",
+            "launch:\n  - node:\n      pkg: undeclared_by_driver\n",
+            under="src",
+        )
+        app = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share driver)/launch/d.launch.yaml"\n',
+            under="src",
+            deps=["driver"],
+        )
+
+        _, findings = check(app, scope=Scope.of([app]))
+
+        undeclared = of_kind(findings, UNDECLARED)
+        self.assertEqual(1, len(undeclared))
+        self.assertEqual(FATAL, undeclared[0].severity)
+        self.assertEqual(os.path.join(driver, "package.xml"), undeclared[0].owner)
+
+    def test_the_workspace_is_found_from_a_relative_path(self):
+        """The hook passes `.`, and `find_workspace_root` compares what it is handed against
+        an absolute `<ws>/src` - so an unresolved path finds no workspace at all."""
+        driver = self.package(
+            "driver", "launch/d.launch.yaml", "launch: []\n", under="src"
+        )
+        app = self.package("app", "launch/app.launch.yaml", "launch: []\n", under="src")
+
+        cwd = os.getcwd()
+        os.chdir(app)
+        try:
+            scope = Scope.of(["."])
+        finally:
+            os.chdir(cwd)
+
+        self.assertEqual(
+            os.path.join(driver, "package.xml"), scope.source.get("driver")
+        )
+
+    def test_a_checkout_outside_any_workspace_still_works(self):
+        """`find_workspace_root` raises when there is no <ws>/src/<pkg> layout above the path.
+        That is a missing tier, not an error."""
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: some_driver\n",
+        )
+
+        scope = Scope.of([pkg])
+
+        self.assertEqual(["app"], sorted(scope.source))
+
     def test_the_checkouts_manifest_wins_over_the_installed_copy(self):
         """Includes resolve through find-pkg-share, so the file read is the installed one. The
         manifest to grade against is still the one in the checkout."""

--- a/tests/test_check_launch_tree.py
+++ b/tests/test_check_launch_tree.py
@@ -1,0 +1,193 @@
+"""The launch-tree check: does everything this tree reaches exist here?"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from package_xml_validation.check_launch_tree import check, main, workspace_is_available
+
+
+class LaunchTreeTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        # A prefix that looks like an install space, so the real lookup can find things
+        self.prefix = os.path.join(self.root, "install")
+        self._env = mock.patch.dict(os.environ, {"AMENT_PREFIX_PATH": self.prefix})
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+        self._tmp.cleanup()
+
+    def install(self, package, relative, text=""):
+        path = os.path.join(self.prefix, "share", package, relative)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def package(self, name, relative, text):
+        path = os.path.join(self.root, name, relative)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return os.path.join(self.root, name)
+
+
+class TestWhatItFinds(LaunchTreeTestCase):
+    def test_a_package_that_is_not_installed(self):
+        """The launch file names it and nothing here provides it."""
+        pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: absent_driver\n",
+        )
+
+        _, missing, dead = check(pkg)
+
+        self.assertEqual(["absent_driver"], missing)
+        self.assertEqual([], dead)
+
+    def test_an_include_that_leads_nowhere(self):
+        """A different fault: the package is there, the launch file it names is not."""
+        self.install("driver", "launch/something_else.launch.yaml", "launch: []\n")
+        pkg = self.package(
+            "app",
+            "launch_manager_components/broken.yaml",
+            "launch:\n  package: driver\n  launch_file: not_shipped.launch.yaml\n",
+        )
+
+        _, missing, dead = check(pkg)
+
+        self.assertEqual([], missing)
+        self.assertEqual(1, len(dead))
+        self.assertIn("not_shipped.launch.yaml", dead[0].launch_file)
+
+    def test_a_missing_package_is_not_also_reported_as_a_dead_include(self):
+        """One fault, one line: the include fails *because* the package is absent."""
+        pkg = self.package(
+            "app",
+            "launch_manager_components/one.yaml",
+            "launch:\n  package: absent\n  launch_file: x.launch.yaml\n",
+        )
+
+        _, missing, dead = check(pkg)
+
+        self.assertEqual(["absent"], missing)
+        self.assertEqual([], dead)
+
+    def test_it_follows_into_other_packages(self):
+        """The reference that breaks a tree is often not in the repository being committed to."""
+        self.install(
+            "aggregator",
+            "launch/pipeline.launch.yaml",
+            "launch:\n  - node:\n      pkg: absent_from_everywhere\n",
+        )
+        pkg = self.package(
+            "app",
+            "launch_manager_components/detection.yaml",
+            "launch:\n  package: aggregator\n  launch_file: pipeline.launch.yaml\n",
+        )
+
+        _, missing, _ = check(pkg)
+
+        self.assertEqual(["absent_from_everywhere"], missing)
+
+    def test_a_healthy_package_reports_nothing(self):
+        self.install("driver", "launch/driver.launch.yaml", "launch: []\n")
+        pkg = self.package(
+            "app",
+            "launch_manager_components/fine.yaml",
+            "launch:\n  package: driver\n  launch_file: driver.launch.yaml\n",
+        )
+
+        _, missing, dead = check(pkg)
+
+        self.assertEqual([], missing)
+        self.assertEqual([], dead)
+
+
+class TestItNeedsAWorkspaceAndSaysSo(LaunchTreeTestCase):
+    """Without AMENT_PREFIX_PATH there is nothing to resolve against, so the check skips."""
+
+    def test_it_reports_that_it_could_not_look(self):
+        with mock.patch.dict(os.environ, {"AMENT_PREFIX_PATH": ""}):
+            self.assertFalse(workspace_is_available())
+
+    def test_it_does_not_fail_when_there_is_nothing_to_resolve_against(self):
+        """Not even with --error: every package would read as missing."""
+        pkg = self.package(
+            "app", "launch/app.launch.yaml", "launch:\n  - node:\n      pkg: anything\n"
+        )
+
+        with mock.patch.dict(os.environ, {"AMENT_PREFIX_PATH": ""}):
+            with mock.patch("sys.argv", ["check-launch-tree", "--error", pkg]):
+                main()  # must not raise SystemExit
+
+
+class TestHowItFails(LaunchTreeTestCase):
+    """Warns by default so it can be introduced to a repository that already has findings."""
+
+    def setUp(self):
+        super().setUp()
+        self.pkg = self.package(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: absent_driver\n",
+        )
+
+    def test_findings_alone_do_not_fail_the_hook(self):
+        with mock.patch("sys.argv", ["check-launch-tree", self.pkg]):
+            main()
+
+    def test_error_makes_findings_fatal(self):
+        with mock.patch("sys.argv", ["check-launch-tree", "--error", self.pkg]):
+            with self.assertRaises(SystemExit) as exit:
+                main()
+        self.assertEqual(1, exit.exception.code)
+
+    def test_a_clean_package_passes_with_error(self):
+        clean = self.package("clean", "launch/x.launch.yaml", "launch: []\n")
+        with mock.patch("sys.argv", ["check-launch-tree", "--error", clean]):
+            main()
+
+
+class TestLaunchArguments(LaunchTreeTestCase):
+    """A tree whose shape depends on an argument is only followed once a value is known."""
+
+    SEED = (
+        "launch:\n"
+        "  - arg:\n"
+        "      name: robot\n"
+        "      default: athena\n"
+        "  - include:\n"
+        '      file: "$(find-pkg-share $(var robot)_sim)/launch/spawn.launch.yaml"\n'
+    )
+
+    def setUp(self):
+        super().setUp()
+        # Only the telemax half of the workspace exists
+        self.install(
+            "telemax_sim",
+            "launch/spawn.launch.yaml",
+            "launch:\n  - node:\n      pkg: telemax_only\n",
+        )
+        self.pkg = self.package("scenario", "launch/robot.launch.yaml", self.SEED)
+
+    def test_the_default_leads_somewhere_that_is_not_installed(self):
+        """`athena_sim` is not here, so the include is reported rather than guessed at."""
+        walk, missing, _ = check(self.pkg)
+
+        self.assertEqual(1, len(walk.unresolved))
+        self.assertIn("athena_sim", walk.unresolved[0].package)
+        self.assertNotIn("telemax_only", missing)
+
+    def test_a_supplied_value_follows_the_other_branch(self):
+        """With robot=telemax the include resolves and what the file behind it names is
+        checked."""
+        walk, missing, _ = check(self.pkg, args={"robot": "telemax"})
+
+        self.assertEqual([], walk.unresolved)
+        self.assertIn("telemax_only", missing)

--- a/tests/test_find_launch_dependencies.py
+++ b/tests/test_find_launch_dependencies.py
@@ -46,6 +46,18 @@ class TestFindLaunchDependencies(unittest.TestCase):
             "find_prefix_pkg",
         ],
         "better_launch_example.launch.py": ["bl_pkg_a", "bl_pkg_b"],
+        # A pattern is a piece of syntax, and `pkg:` means different things in different
+        # languages. In Python it is a type annotation or part of a string, never a mapping
+        # key - reading it as one reported packages named `str` and `robot`.
+        "python_annotation_and_literal.py": [],
+        # Any key *ending* in `pkg` used to match, because nothing anchored the pattern.
+        "yaml_keys_ending_in_pkg.launch.yml": ["real_package", "quoted_package"],
+        # ... and the anchor has to allow the `- ` of a sequence item, or every hector
+        # component definition would stop being scanned.
+        "yaml_sequence_item_package.yaml": [
+            "sequence_item_package",
+            "another_sequence_package",
+        ],
     }
 
     # Directory where example launch files live
@@ -120,3 +132,70 @@ class TestFindLaunchDependencies(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPatternsAreScopedToTheirFormat(unittest.TestCase):
+    """A pattern only applies to the languages it is syntax for.
+
+    The three cases below were all live false positives. They are asserted directly, rather
+    than only through the example files, because the mechanism is the point: a Python file
+    must not be searched for YAML mapping keys, whatever it happens to contain.
+    """
+
+    BASE_DIR = os.path.join(os.path.dirname(__file__), "examples", "launch_examples")
+
+    def scan(self, filename):
+        found = set()
+        scan_file(os.path.join(self.BASE_DIR, filename), found)
+        return found
+
+    def test_a_python_type_annotation_is_not_a_package(self):
+        """`def resolve(pkg: str, ...)` reported a package named `str`."""
+        self.assertNotIn("str", self.scan("python_annotation_and_literal.py"))
+
+    def test_a_string_containing_pkg_is_not_a_package(self):
+        """`"pkg:robot.launch.yaml"` in a unit test reported a package named `robot`, and the
+        hook then demanded a <test_depend> on it."""
+        self.assertNotIn("robot", self.scan("python_annotation_and_literal.py"))
+
+    def test_a_key_merely_ending_in_pkg_is_not_a_reference(self):
+        """`mypkg: foo` matched, because nothing anchored the pattern to the start of a key."""
+        found = self.scan("yaml_keys_ending_in_pkg.launch.yml")
+        self.assertNotIn("not_a_package", found)
+        self.assertNotIn("also_not_a_package", found)
+
+    def test_the_real_references_beside_them_still_match(self):
+        """The point of the fix is precision, not silence."""
+        found = self.scan("yaml_keys_ending_in_pkg.launch.yml")
+        self.assertIn("real_package", found)
+        self.assertIn("quoted_package", found)
+
+    def test_a_sequence_item_key_still_matches(self):
+        """`- package: x` is how every hector component definition names its package, so the
+        anchor has to allow the leading dash."""
+        found = self.scan("yaml_sequence_item_package.yaml")
+        self.assertEqual({"sequence_item_package", "another_sequence_package"}, found)
+
+    def test_the_toml_form_stays_out_of_yaml_and_python(self):
+        """`package = "x"` is a TOML form. It is also an ordinary assignment in Python, which
+        is why it was scoped in the first place - that scoping is now the general rule.
+
+        Selected by the pattern's own declared formats rather than by asking which patterns
+        apply to TOML: the latter also returns the format-agnostic ones like
+        `$(find-pkg-share x)`, which are meant to apply everywhere.
+        """
+        from package_xml_validation.helpers.find_launch_dependencies import (
+            FORMAT_TOML,
+            PATTERNS,
+        )
+
+        toml_only = [rx for rx, formats in PATTERNS if formats == {FORMAT_TOML}]
+
+        self.assertTrue(toml_only, "no TOML-specific pattern left to check")
+        for rx in toml_only:
+            self.assertIn("package", rx)
+            found = set()
+            scan_file(
+                os.path.join(self.BASE_DIR, "python_annotation_and_literal.py"), found
+            )
+            self.assertEqual(set(), found)

--- a/tests/test_find_launch_dependencies.py
+++ b/tests/test_find_launch_dependencies.py
@@ -46,14 +46,13 @@ class TestFindLaunchDependencies(unittest.TestCase):
             "find_prefix_pkg",
         ],
         "better_launch_example.launch.py": ["bl_pkg_a", "bl_pkg_b"],
-        # A pattern is a piece of syntax, and `pkg:` means different things in different
-        # languages. In Python it is a type annotation or part of a string, never a mapping
-        # key - reading it as one reported packages named `str` and `robot`.
+        # `pkg:` and `package =` are YAML and TOML syntax; in Python they are an annotation
+        # and an assignment.
         "python_annotation_and_literal.py": [],
-        # Any key *ending* in `pkg` used to match, because nothing anchored the pattern.
+        # A key merely *ending* in `pkg` is not a reference.
         "yaml_keys_ending_in_pkg.launch.yml": ["real_package", "quoted_package"],
-        # ... and the anchor has to allow the `- ` of a sequence item, or every hector
-        # component definition would stop being scanned.
+        # ... but the anchor allows the `- ` of a sequence item, which is how every hector
+        # component definition names its package.
         "yaml_sequence_item_package.yaml": [
             "sequence_item_package",
             "another_sequence_package",
@@ -137,9 +136,8 @@ if __name__ == "__main__":
 class TestPatternsAreScopedToTheirFormat(unittest.TestCase):
     """A pattern only applies to the languages it is syntax for.
 
-    The three cases below were all live false positives. They are asserted directly, rather
-    than only through the example files, because the mechanism is the point: a Python file
-    must not be searched for YAML mapping keys, whatever it happens to contain.
+    The Python fixture writes each form at the start of a line, where anchoring alone would let
+    it through, so these fail if the format scoping is removed and not only if the anchor is.
     """
 
     BASE_DIR = os.path.join(os.path.dirname(__file__), "examples", "launch_examples")
@@ -149,53 +147,54 @@ class TestPatternsAreScopedToTheirFormat(unittest.TestCase):
         scan_file(os.path.join(self.BASE_DIR, filename), found)
         return found
 
-    def test_a_python_type_annotation_is_not_a_package(self):
-        """`def resolve(pkg: str, ...)` reported a package named `str`."""
+    def test_a_python_annotation_is_not_a_mapping_key(self):
+        """`pkg: str = "hello"` at module level: a YAML key everywhere but in Python."""
         self.assertNotIn("str", self.scan("python_annotation_and_literal.py"))
 
+    def test_a_python_assignment_is_not_the_toml_form(self):
+        """`package = "x"` names a package in better_launch TOML and nothing in Python."""
+        self.assertNotIn(
+            "sneaky_toml_form", self.scan("python_annotation_and_literal.py")
+        )
+
     def test_a_string_containing_pkg_is_not_a_package(self):
-        """`"pkg:robot.launch.yaml"` in a unit test reported a package named `robot`, and the
-        hook then demanded a <test_depend> on it."""
+        """A `"pkg:robot.launch.yaml"` literal names a file, not a dependency."""
         self.assertNotIn("robot", self.scan("python_annotation_and_literal.py"))
 
     def test_a_key_merely_ending_in_pkg_is_not_a_reference(self):
-        """`mypkg: foo` matched, because nothing anchored the pattern to the start of a key."""
+        """`mypkg: foo` is a key of its own, not the `pkg:` key."""
         found = self.scan("yaml_keys_ending_in_pkg.launch.yml")
         self.assertNotIn("not_a_package", found)
         self.assertNotIn("also_not_a_package", found)
 
     def test_the_real_references_beside_them_still_match(self):
-        """The point of the fix is precision, not silence."""
+        """The point is precision, not silence."""
         found = self.scan("yaml_keys_ending_in_pkg.launch.yml")
         self.assertIn("real_package", found)
         self.assertIn("quoted_package", found)
 
     def test_a_sequence_item_key_still_matches(self):
-        """`- package: x` is how every hector component definition names its package, so the
-        anchor has to allow the leading dash."""
+        """`- package: x` is how every hector component definition names its package."""
         found = self.scan("yaml_sequence_item_package.yaml")
         self.assertEqual({"sequence_item_package", "another_sequence_package"}, found)
 
-    def test_the_toml_form_stays_out_of_yaml_and_python(self):
-        """`package = "x"` is a TOML form. It is also an ordinary assignment in Python, which
-        is why it was scoped in the first place - that scoping is now the general rule.
-
-        Selected by the pattern's own declared formats rather than by asking which patterns
-        apply to TOML: the latter also returns the format-agnostic ones like
-        `$(find-pkg-share x)`, which are meant to apply everywhere.
-        """
+    def test_every_format_specific_pattern_is_withheld_from_the_others(self):
+        """The mechanism itself, rather than one fixture's worth of it: whatever a pattern
+        declares it is syntax for is exactly what `_patterns_for` hands it."""
         from package_xml_validation.helpers.find_launch_dependencies import (
-            FORMAT_TOML,
+            ANY_FORMAT,
+            COMPILED_PATTERNS,
             PATTERNS,
+            _patterns_for,
         )
 
-        toml_only = [rx for rx, formats in PATTERNS if formats == {FORMAT_TOML}]
+        specific = [i for i, (_, fmts) in enumerate(PATTERNS) if fmts != ANY_FORMAT]
+        self.assertTrue(specific, "no format-specific pattern left to check")
 
-        self.assertTrue(toml_only, "no TOML-specific pattern left to check")
-        for rx in toml_only:
-            self.assertIn("package", rx)
-            found = set()
-            scan_file(
-                os.path.join(self.BASE_DIR, "python_annotation_and_literal.py"), found
-            )
-            self.assertEqual(set(), found)
+        for fmt in ANY_FORMAT:
+            applied = {i for _, i in _patterns_for(fmt)}
+            for i in specific:
+                declared = fmt in COMPILED_PATTERNS[i][1]
+                self.assertEqual(
+                    declared, i in applied, f"pattern {PATTERNS[i][0]!r} in {fmt}"
+                )

--- a/tests/test_precommit_hook_manifest.py
+++ b/tests/test_precommit_hook_manifest.py
@@ -1,0 +1,73 @@
+"""The contract `.pre-commit-hooks.yaml` makes with pre-commit.
+
+Nothing else covers this file, and what it declares is not cosmetic: pre-commit throws away a
+passing hook's output, so a hook that warns without `verbose: true` warns into nothing.
+"""
+
+import os
+import re
+import unittest
+
+import yaml
+
+MANIFEST = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), ".pre-commit-hooks.yaml"
+)
+
+
+def hook(hook_id):
+    with open(MANIFEST, encoding="utf-8") as f:
+        for entry in yaml.safe_load(f):
+            if entry["id"] == hook_id:
+                return entry
+    raise AssertionError(f"no hook with id {hook_id!r} in {MANIFEST}")
+
+
+class TestCheckLaunchTreeHook(unittest.TestCase):
+    def setUp(self):
+        self.hook = hook("check-launch-tree")
+
+    def test_its_warnings_are_shown(self):
+        """pre-commit prints a hook's output only when it fails, is verbose, or changed a
+        file. This one exits zero on everything a CI runner cannot help, so without `verbose`
+        those findings reach nobody."""
+        self.assertIs(True, self.hook.get("verbose"))
+
+    def test_it_is_not_handed_filenames(self):
+        """It walks whole packages, not the files that happen to be staged."""
+        self.assertIs(False, self.hook["pass_filenames"])
+
+    def test_every_format_the_scanner_seeds_from_triggers_it(self):
+        pattern = re.compile(self.hook["files"])
+        for path in (
+            "launch/a.launch.py",
+            "launch/a.launch.xml",
+            "launch/a.launch.yaml",
+            "launch/a.launch.yml",
+            "launch/a.launch",
+            "launch/a.toml",
+            "components/a.yaml",
+            "src/pkg/launch_manager_components/a.yaml",
+            "src/pkg/launch_manager_configs/a.yaml",
+        ):
+            self.assertRegex(path, pattern)
+
+    def test_a_directory_merely_ending_in_launch_does_not(self):
+        pattern = re.compile(self.hook["files"])
+        for path in ("mylaunch/a.py", "src/prelaunch/a.yaml", "docs/launching.md"):
+            self.assertNotRegex(path, pattern)
+
+
+class TestPreCommitAcceptsTheManifest(unittest.TestCase):
+    """Schema validation, when pre-commit itself is around to do it."""
+
+    def test_it_loads(self):
+        try:
+            from pre_commit.clientlib import load_manifest
+        except ImportError:
+            self.skipTest("pre-commit is not installed")
+
+        ids = [entry["id"] for entry in load_manifest(MANIFEST)]
+
+        self.assertIn("check-launch-tree", ids)
+        self.assertIn("format-package-xml", ids)

--- a/tests/test_scan_from.py
+++ b/tests/test_scan_from.py
@@ -268,6 +268,44 @@ class TestIncludesWrittenInPython(ScanFromTestCase):
 
         self.assertIn("gz_internals", walk.packages)
 
+    def test_a_qualified_call_is_followed(self):
+        """`launch.actions.IncludeLaunchDescription(...)`, matched on the trailing name.
+
+        Matching `ast.Name` only made the qualified form produce no edge at all - not even an
+        unreadable one - so everything below it went unread with nothing to say so.
+        """
+        self.ws.write(
+            "other", "launch/child.launch.py", "Node(package='deep_package')\n"
+        )
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.py",
+            "import launch, ament_index_python\n"
+            "launch.actions.IncludeLaunchDescription(\n"
+            "    os.path.join(\n"
+            "        ament_index_python.get_package_share_directory('other'),\n"
+            "        'launch', 'child.launch.py')\n"
+            ")\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("deep_package", walk.packages)
+        self.assertEqual([], walk.unresolved)
+
+    def test_a_qualified_call_it_cannot_read_is_still_reported(self):
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.py",
+            "import launch\n"
+            "launch.actions.IncludeLaunchDescription(pick_a_launch_file())\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual(1, len(walk.unresolved))
+        self.assertEqual(2, walk.unresolved[0].line)
+
     def test_an_include_it_cannot_read_is_reported_with_its_line(self):
         """An include assembled at runtime cannot be followed, so it is reported."""
         seed = self.ws.write(
@@ -468,3 +506,62 @@ class TestFindingALaunchFileInsideAPackage(ScanFromTestCase):
 
         self.assertEqual(1, len(walk.unresolved))
         self.assertIn("not_anywhere.launch.yaml", walk.unresolved[0].launch_file)
+
+    def test_a_written_out_path_does_not_fall_back_to_the_basename(self):
+        """The search is for components only. A renamed or uninstalled launch file used to
+        resolve to a same-named one elsewhere in the package, reporting what *that* file
+        names and hiding the real finding."""
+        self.ws.write(
+            "present",
+            "somewhere_else/gone.launch.yaml",
+            "launch:\n  - node:\n      pkg: from_the_wrong_file\n",
+        )
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share present)/launch/gone.launch.yaml"\n',
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual(1, len(walk.unresolved))
+        self.assertNotIn("from_the_wrong_file", walk.packages)
+
+
+class TestComponentBlocks(ScanFromTestCase):
+    """`package` and `launch_file` have to belong to the same mapping."""
+
+    def test_a_node_only_component_does_not_borrow_the_next_launch_file(self):
+        """A regex scanning the following lines paired the first component's `package` with the
+        second's `launch_file`: a finding against a package that ships nothing of the sort, and
+        the real include left unfollowed."""
+        self.ws.write(
+            "pkg_b",
+            "launch/b.launch.yaml",
+            "launch:\n  - node:\n      pkg: only_under_pkg_b\n",
+        )
+        seed = self.ws.write(
+            "config",
+            "components/two.yaml",
+            "components:\n"
+            "  - name: one\n"
+            "    package: pkg_a\n"
+            "    node: some_node\n"
+            "  - name: two\n"
+            "    package: pkg_b\n"
+            "    launch_file: b.launch.yaml\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual([], walk.unresolved)
+        self.assertIn("only_under_pkg_b", walk.packages)
+
+    def test_an_unparsable_file_yields_no_component_edges(self):
+        seed = self.ws.write(
+            "config", "components/broken.yaml", "components:\n  - [unclosed\n"
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual([], walk.unresolved)

--- a/tests/test_scan_from.py
+++ b/tests/test_scan_from.py
@@ -1,0 +1,470 @@
+"""Following a launch tree from a seed, rather than scanning a directory.
+
+The property these tests protect is that the walk never overstates its coverage: an include it
+cannot follow has to be reported, not skipped.
+"""
+
+import os
+import tempfile
+import unittest
+
+from package_xml_validation.helpers.find_launch_dependencies import (
+    scan_file_detailed,
+    scan_from,
+)
+
+
+class Workspace:
+    """A throwaway tree of launch files, with a share lookup that only knows what we put in it."""
+
+    def __init__(self, root):
+        self.root = root
+
+    def write(self, package, relative, text):
+        path = os.path.join(self.root, package, relative)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def lookup(self, package):
+        share = os.path.join(self.root, package)
+        return share if os.path.isdir(share) else None
+
+
+class ScanFromTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Workspace(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+
+class TestFollowingIncludes(ScanFromTestCase):
+    def test_it_reads_the_file_an_include_points_at(self):
+        """A package this launch pulls in may name packages of its own."""
+        self.ws.write(
+            "downstream",
+            "launch/child.launch.yaml",
+            "launch:\n  - node:\n      pkg: only_named_downstream\n",
+        )
+        seed = self.ws.write(
+            "upstream",
+            "launch/parent.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share downstream)/launch/child.launch.yaml"\n',
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("only_named_downstream", walk.packages)
+        self.assertEqual(2, len(walk.visited))
+        self.assertEqual([], walk.unresolved)
+
+    def test_a_component_definition_is_an_include_too(self):
+        """`package:` + `launch_file:` is how a component names what it starts."""
+        self.ws.write(
+            "aggregator",
+            "launch/pipeline.launch.yaml",
+            "launch:\n  - node:\n      pkg: a_detector\n",
+        )
+        seed = self.ws.write(
+            "config",
+            "components/detection.yaml",
+            "launch:\n  package: aggregator\n  launch_file: pipeline.launch.yaml\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("a_detector", walk.packages)
+
+    def test_a_leaf_reference_is_not_descended_into(self):
+        """`pkg:` on a node has no launch file behind it, so nothing is descended into."""
+        self.ws.write(
+            "some_driver",
+            "launch/unrelated.launch.yaml",
+            "launch:\n  - node:\n      pkg: never_launched_by_us\n",
+        )
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: some_driver\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("some_driver", walk.packages)
+        self.assertNotIn("never_launched_by_us", walk.packages)
+
+    def test_a_cycle_terminates(self):
+        a = self.ws.write(
+            "a",
+            "launch/a.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share b)/launch/b.launch.yaml"\n',
+        )
+        self.ws.write(
+            "b",
+            "launch/b.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share a)/launch/a.launch.yaml"\n',
+        )
+
+        walk = scan_from(a, share_lookup=self.ws.lookup)
+
+        self.assertEqual(2, len(walk.visited))
+
+
+class TestItNeverOverstatesWhatItRead(ScanFromTestCase):
+    """A walk that skips what it cannot resolve reports full coverage of a partly read tree."""
+
+    def test_a_computed_package_name_is_reported_not_skipped(self):
+        """A package name assembled from a substitution, with a whole subtree behind it."""
+        seed = self.ws.write(
+            "sim",
+            "launch/sim.launch.yaml",
+            "launch:\n  - include:\n"
+            '      file: "$(find-pkg-share $(var robot)_gazebo)/launch/spawn.launch.py"\n',
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual(1, len(walk.unresolved))
+        self.assertIn("$(var robot)_gazebo", walk.unresolved[0].package)
+        self.assertEqual(3, walk.unresolved[0].line)
+
+    def test_an_include_of_a_package_that_is_not_installed_is_reported(self):
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share absent)/launch/x.launch.yaml"\n',
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual(["absent"], [e.package for e in walk.unresolved])
+
+    def test_an_include_of_a_file_that_is_not_there_is_reported(self):
+        """The package exists and the file does not - a rename, or a missing install rule."""
+        self.ws.write("present", "launch/other.launch.yaml", "launch: []\n")
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.yaml",
+            'launch:\n  - include:\n      file: "$(find-pkg-share present)/launch/gone.launch.yaml"\n',
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual(1, len(walk.unresolved))
+        self.assertEqual("launch/gone.launch.yaml", walk.unresolved[0].launch_file)
+
+    def test_a_data_file_is_not_mistaken_for_an_include(self):
+        """`$(find-pkg-share x)/config/params.yaml` has an extension we scan but is not an
+        include."""
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n  - node:\n      pkg: app_node\n"
+            '      param: "$(find-pkg-share app)/config/params.yaml"\n',
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual([], walk.unresolved)
+
+
+class TestProvenance(ScanFromTestCase):
+    """Every reference carries the file and line it was written on."""
+
+    def test_each_reference_carries_its_line(self):
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.yaml",
+            "launch:\n"
+            "  - node:\n"
+            "      pkg: first_package\n"
+            "  - node:\n"
+            "      pkg: second_package\n",
+        )
+
+        by_name = {r.package: r.line for r in scan_file_detailed(seed)}
+
+        self.assertEqual(3, by_name["first_package"])
+        self.assertEqual(5, by_name["second_package"])
+
+    def test_a_multi_line_comment_does_not_shift_the_lines_after_it(self):
+        """Comments are blanked out, not deleted, so later line numbers still hold."""
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.xml",
+            "<launch>\n"
+            "  <!-- a comment\n"
+            "       spanning\n"
+            "       several lines -->\n"
+            '  <node pkg="after_the_comment"/>\n'
+            "</launch>\n",
+        )
+
+        found = scan_file_detailed(seed)
+
+        self.assertEqual(1, len(found))
+        self.assertEqual(5, found[0].line)
+
+
+class TestIncludesWrittenInPython(ScanFromTestCase):
+    """A tree can hide most of itself behind a single `IncludeLaunchDescription`."""
+
+    def test_the_documented_shape_is_followed(self):
+        self.ws.write(
+            "described",
+            "launch/description.launch.py",
+            "def generate_launch_description():\n"
+            "    return [Node(package='only_named_downstream', executable='x')]\n",
+        )
+        seed = self.ws.write(
+            "sim",
+            "launch/spawn.launch.py",
+            "from launch.actions import IncludeLaunchDescription\n"
+            "def generate_launch_description():\n"
+            "    return [IncludeLaunchDescription(\n"
+            "        PathJoinSubstitution([\n"
+            "            FindPackageShare('described'), 'launch', 'description.launch.py',\n"
+            "        ])\n"
+            "    )]\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("only_named_downstream", walk.packages)
+        self.assertEqual([], walk.unresolved)
+
+    def test_the_os_path_join_shape_is_followed(self):
+        self.ws.write(
+            "other", "launch/child.launch.py", "Node(package='deep_package')\n"
+        )
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.py",
+            "IncludeLaunchDescription(\n"
+            "    os.path.join(get_package_share_directory('other'), 'launch', 'child.launch.py')\n"
+            ")\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("deep_package", walk.packages)
+
+    def test_a_lookup_hoisted_to_a_constant_is_followed(self):
+        """`GZ = get_package_share_directory("gz")` at module level, used further down."""
+        self.ws.write("gz", "launch/gz.launch.py", "Node(package='gz_internals')\n")
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.py",
+            "GZ = get_package_share_directory('gz')\n"
+            "IncludeLaunchDescription(\n"
+            "    PathJoinSubstitution([GZ, 'launch', 'gz.launch.py'])\n"
+            ")\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("gz_internals", walk.packages)
+
+    def test_an_include_it_cannot_read_is_reported_with_its_line(self):
+        """An include assembled at runtime cannot be followed, so it is reported."""
+        seed = self.ws.write(
+            "app",
+            "launch/app.launch.py",
+            "def generate_launch_description():\n"
+            "    chosen = pick_a_launch_file()\n"
+            "    return [IncludeLaunchDescription(chosen)]\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual(1, len(walk.unresolved))
+        self.assertEqual(3, walk.unresolved[0].line)
+        self.assertIn("could not read", walk.unresolved[0].launch_file)
+
+
+class TestSubstitutedArguments(ScanFromTestCase):
+    """`$(var x)` inside a package name."""
+
+    SEED = (
+        "launch:\n"
+        "  - arg:\n"
+        "      name: robot\n"
+        "      default: athena\n"
+        "  - arg:\n"
+        "      name: robot_name\n"
+        '      default: "$(var robot)"\n'
+        "  - include:\n"
+        '      file: "$(find-pkg-share $(var robot_name)_sim)/launch/spawn.launch.yaml"\n'
+    )
+
+    def test_a_declared_default_resolves_the_include(self):
+        """And through a chain: robot_name defaults to $(var robot), which defaults to athena."""
+        self.ws.write(
+            "athena_sim",
+            "launch/spawn.launch.yaml",
+            "launch:\n  - node:\n      pkg: found_only_behind_the_substitution\n",
+        )
+        seed = self.ws.write("scenario", "launch/robot.launch.yaml", self.SEED)
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("found_only_behind_the_substitution", walk.packages)
+        self.assertEqual([], walk.unresolved)
+
+    def test_the_callers_value_wins_over_the_default(self):
+        """A caller that knows its arguments follows the tree that will come up."""
+        self.ws.write(
+            "telemax_sim",
+            "launch/spawn.launch.yaml",
+            "launch:\n  - node:\n      pkg: a_telemax_only_package\n",
+        )
+        seed = self.ws.write("scenario", "launch/robot.launch.yaml", self.SEED)
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup, args={"robot": "telemax"})
+
+        self.assertIn("a_telemax_only_package", walk.packages)
+
+    def test_an_unknown_argument_leaves_the_include_unresolved(self):
+        """Fails safe: what cannot be expanded is reported, never guessed."""
+        seed = self.ws.write(
+            "scenario",
+            "launch/robot.launch.yaml",
+            "launch:\n  - include:\n"
+            '      file: "$(find-pkg-share $(var never_declared)_sim)/launch/x.launch.yaml"\n',
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual(1, len(walk.unresolved))
+        self.assertIn("$(var never_declared)", walk.unresolved[0].package)
+
+    def test_arguments_defined_in_terms_of_each_other_do_not_hang(self):
+        from package_xml_validation.helpers.find_launch_dependencies import expand_vars
+
+        self.assertEqual(
+            "$(var a)", expand_vars("$(var a)", {"a": "$(var b)", "b": "$(var a)"})
+        )
+
+    def test_a_launch_file_that_is_not_valid_yaml_expands_nothing(self):
+        """An unparsable file is not a crash and not a guess - the names stay as written."""
+        from package_xml_validation.helpers.find_launch_dependencies import (
+            declared_args,
+        )
+
+        broken = self.ws.write(
+            "app", "launch/broken.launch.yaml", "launch:\n  - [unclosed\n"
+        )
+
+        self.assertEqual({}, declared_args(broken))
+
+
+class TestScanningAWholeDirectory(ScanFromTestCase):
+    """`scan_files` plus recursion, as one walk over every seed rather than one walk each."""
+
+    def test_every_launch_file_in_the_directory_is_a_seed(self):
+        self.ws.write(
+            "app", "launch/one.launch.yaml", "launch:\n  - node:\n      pkg: from_one\n"
+        )
+        self.ws.write(
+            "app", "launch/two.launch.yaml", "launch:\n  - node:\n      pkg: from_two\n"
+        )
+
+        from package_xml_validation.helpers.find_launch_dependencies import (
+            scan_directory,
+        )
+
+        walk = scan_directory(
+            os.path.join(self.ws.root, "app"), share_lookup=self.ws.lookup
+        )
+
+        self.assertIn("from_one", walk.packages)
+        self.assertIn("from_two", walk.packages)
+
+    def test_a_file_two_seeds_both_reach_is_read_once(self):
+        """Sibling launch files include the same things; the shared visited set reads them once."""
+        from package_xml_validation.helpers.find_launch_dependencies import (
+            scan_directory,
+        )
+
+        self.ws.write(
+            "common",
+            "launch/shared.launch.yaml",
+            "launch:\n  - node:\n      pkg: shared_dep\n",
+        )
+        for name in ("one", "two", "three"):
+            self.ws.write(
+                "app",
+                f"launch/{name}.launch.yaml",
+                'launch:\n  - include:\n      file: "$(find-pkg-share common)/launch/shared.launch.yaml"\n',
+            )
+
+        walk = scan_directory(
+            os.path.join(self.ws.root, "app"), share_lookup=self.ws.lookup
+        )
+
+        read_shared = [f for f in walk.visited if f.endswith("shared.launch.yaml")]
+        self.assertEqual(
+            1, len(read_shared), "the shared include was read more than once"
+        )
+        self.assertEqual(4, len(walk.visited))
+
+    def test_the_same_file_reached_twice_is_not_reported_twice(self):
+        from package_xml_validation.helpers.find_launch_dependencies import (
+            scan_directory,
+        )
+
+        self.ws.write(
+            "common",
+            "launch/shared.launch.yaml",
+            "launch:\n  - node:\n      pkg: shared_dep\n",
+        )
+        for name in ("one", "two"):
+            self.ws.write(
+                "app",
+                f"launch/{name}.launch.yaml",
+                'launch:\n  - include:\n      file: "$(find-pkg-share common)/launch/shared.launch.yaml"\n',
+            )
+
+        walk = scan_directory(
+            os.path.join(self.ws.root, "app"), share_lookup=self.ws.lookup
+        )
+
+        self.assertEqual(1, [r.package for r in walk.references].count("shared_dep"))
+
+
+class TestFindingALaunchFileInsideAPackage(ScanFromTestCase):
+    """A component names its launch file by bare filename; the manager finds it wherever it is."""
+
+    def test_a_launch_file_in_a_subdirectory_is_found(self):
+        self.ws.write(
+            "nav",
+            "launch/navigation/nav2.launch.yaml",
+            "launch:\n  - node:\n      pkg: a_planner\n",
+        )
+        seed = self.ws.write(
+            "config",
+            "components/nav2.yaml",
+            "launch:\n  package: nav\n  launch_file: nav2.launch.yaml\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertIn("a_planner", walk.packages)
+        self.assertEqual([], walk.unresolved)
+
+    def test_a_launch_file_that_exists_nowhere_stays_unresolved(self):
+        """The fallback must not turn a real finding into a pass."""
+        self.ws.write("driver", "launch/something_else.launch.yaml", "launch: []\n")
+        seed = self.ws.write(
+            "config",
+            "components/broken.yaml",
+            "launch:\n  package: driver\n  launch_file: not_anywhere.launch.yaml\n",
+        )
+
+        walk = scan_from(seed, share_lookup=self.ws.lookup)
+
+        self.assertEqual(1, len(walk.unresolved))
+        self.assertIn("not_anywhere.launch.yaml", walk.unresolved[0].launch_file)

--- a/tests/test_scan_from.py
+++ b/tests/test_scan_from.py
@@ -269,11 +269,7 @@ class TestIncludesWrittenInPython(ScanFromTestCase):
         self.assertIn("gz_internals", walk.packages)
 
     def test_a_qualified_call_is_followed(self):
-        """`launch.actions.IncludeLaunchDescription(...)`, matched on the trailing name.
-
-        Matching `ast.Name` only made the qualified form produce no edge at all - not even an
-        unreadable one - so everything below it went unread with nothing to say so.
-        """
+        """`launch.actions.IncludeLaunchDescription(...)`, matched on the trailing name."""
         self.ws.write(
             "other", "launch/child.launch.py", "Node(package='deep_package')\n"
         )
@@ -508,9 +504,8 @@ class TestFindingALaunchFileInsideAPackage(ScanFromTestCase):
         self.assertIn("not_anywhere.launch.yaml", walk.unresolved[0].launch_file)
 
     def test_a_written_out_path_does_not_fall_back_to_the_basename(self):
-        """The search is for components only. A renamed or uninstalled launch file used to
-        resolve to a same-named one elsewhere in the package, reporting what *that* file
-        names and hiding the real finding."""
+        """The basename search is for components only. Elsewhere a renamed or uninstalled
+        launch file must not resolve to a same-named one elsewhere in the package."""
         self.ws.write(
             "present",
             "somewhere_else/gone.launch.yaml",
@@ -532,9 +527,8 @@ class TestComponentBlocks(ScanFromTestCase):
     """`package` and `launch_file` have to belong to the same mapping."""
 
     def test_a_node_only_component_does_not_borrow_the_next_launch_file(self):
-        """A regex scanning the following lines paired the first component's `package` with the
-        second's `launch_file`: a finding against a package that ships nothing of the sort, and
-        the real include left unfollowed."""
+        """A component with no `launch_file` of its own is not an include, however close the
+        next component's is."""
         self.ws.write(
             "pkg_b",
             "launch/b.launch.yaml",


### PR DESCRIPTION
## Summary

**Pattern scoping.** `pkg:` is a mapping key in YAML and a type annotation in Python, so scanning Python source for YAML keys reported `pkg: str` as a package named `str`. Each pattern now declares the formats it applies to.

**New hook: `check-launch-tree`.** Follows every include out of a package's launch files, across package boundaries, and reports what does not resolve, e.g.  a package that is not installed, or an include whose package is present but whose launch file is not. 

