### PR TITLE
Per-host dependency derivation for launch-manager install sets 

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,41 @@ The on-disk file now matches the **After** snippet above. The exit code is non-z
 * **CMake Synchronization:** Compares `package.xml` against `CMakeLists.txt` to ensure build dependencies match, adding missing entries as `<depend>` or `<test_depend>`. Calls of the form `find_package(<pkg> QUIET)` are treated as optional and skipped. all other forms such as `find_package(<pkg>)`, `find_package(<pkg> REQUIRED)`, and `find_package(<pkg> REQUIRED QUIET)` are enforced in `package.xml`.
 * **Rosdep Validation:** Verifies that your dependency names exist as valid keys in the rosdep database.
 
+### Launch-Manager Install Sets
+
+Some workspaces keep every launch file in one package and declare the dependencies in sibling
+*install sets*, one per machine — the shape you end up with when a robot's computers are not all
+big enough to install everything. Neither of the checks above can make sense of that on its own:
+the package naming a dependency is not the package declaring it.
+
+A package says which machine it is the install set for in its own `<export>` section:
+
+```xml
+<export>
+  <build_type>ament_cmake</build_type>
+  <launch_manager_host>athena-gripper</launch_manager_host>
+</export>
+```
+
+With that, the validator reads `launch_manager_configs/*.yaml` to see which components run on that
+host, follows each component into its launch tree, and checks the install set against everything
+those trees name. `--auto-fill-missing-deps` adds what is missing. The package holding the launch
+files stops reporting those references as missing, since an install set declares them.
+
+The whole feature is opt-in: with no `launch_manager_host` export anywhere, nothing changes.
+
+Three properties worth knowing:
+
+* **Additive only.** The derivation is a lower bound — a controller plugin named by class in a
+  parameter file, or a package handed to a generic component as an argument, is named nowhere a
+  launch-file scan can reach. A declared dependency that was not derived is left alone and not
+  reported; removing it would uninstall something the robot needs.
+* **Nothing is filled from an incomplete derivation.** If a component's definition cannot be found
+  — commonly because the shared component library is not installed — the run says so and fills
+  nothing, rather than writing a manifest that looks complete.
+* **A host with no install set is reported.** If a configuration launches on a machine no package
+  claims, nothing declares what that machine runs, and no per-package check could notice.
+
 ### Launch Tree Integrity
 
 The separate `check-launch-tree` hook follows every include out of a package's launch files, across package boundaries, and grades what it finds by whether anyone can act on it:

--- a/package_xml_validation/check_launch_tree.py
+++ b/package_xml_validation/check_launch_tree.py
@@ -44,6 +44,7 @@ from .helpers.formatter.dependency_queries import (
     get_package_name,
     retrieve_exec_dependencies_with_conditions,
 )
+from .helpers.launch_manager import declared_host, find_config_package
 from .helpers.workspace import find_package_xml_files, find_workspace_root
 
 __all__ = [
@@ -127,6 +128,18 @@ class Scope(NamedTuple):
 
     ignored: frozenset = frozenset()
 
+    delegated: frozenset = frozenset()
+    """Dependencies declared by a launch-manager install set.
+
+    A package holding the launch files for several hosts declares almost nothing itself, since
+    each host installs only what it runs. These are the references that are declared, just not
+    where the launch file naming them lives.
+    """
+
+    config_manifest: Optional[str] = None
+    """The manifest of the package holding `launch_manager_configs/`, the only one whose launch
+    files may leave their dependencies to an install set."""
+
     @classmethod
     def of(
         cls,
@@ -144,7 +157,20 @@ class Scope(NamedTuple):
         index: dict = {}
         for root in (*fatal_under, *workspace_sources(paths), *paths):
             index.update(_index(find_package_xml_files([root])))
-        return cls(index, fatal_under, ignored)
+
+        delegated: set = set()
+        for manifest in index.values():
+            if _read(manifest).host:
+                delegated.update(_read(manifest).declared)
+
+        config = find_config_package(sorted(package_dirs_under(paths)))
+        return cls(
+            index,
+            fatal_under,
+            ignored,
+            frozenset(delegated),
+            os.path.join(config, "package.xml") if config else None,
+        )
 
     def severity_of(self, manifest: Optional[str]) -> str:
         if manifest is None:
@@ -208,11 +234,22 @@ def check(
 
 # ── Reading the manifests a walk is graded against ───────────────────────────────────────
 
-_MANIFESTS: "dict[str, tuple[Optional[str], frozenset, frozenset]]" = {}
+
+class Manifest(NamedTuple):
+    """What a `package.xml` says that matters here."""
+
+    name: Optional[str]
+    declared: frozenset
+    ignored: frozenset
+    host: Optional[str] = None
+    """The launch-manager host this package is the install set for, if it claims one."""
 
 
-def _read(manifest: str) -> "tuple[Optional[str], frozenset, frozenset]":
-    """`(package name, declared exec deps, names to ignore)`, parsed once per path.
+_MANIFESTS: "dict[str, Manifest]" = {}
+
+
+def _read(manifest: str) -> Manifest:
+    """Read a `package.xml`, once per path.
 
     Exec dependencies, because a launch file names what it runs. Conditions are evaluated and
     `<!-- validator:ignore ... -->` is honoured, so this agrees with what
@@ -223,17 +260,18 @@ def _read(manifest: str) -> "tuple[Optional[str], frozenset, frozenset]":
             parser = ET.XMLParser(no_network=True, resolve_entities=False)
             root = ET.parse(manifest, parser).getroot()
         except (OSError, ET.XMLSyntaxError):
-            _MANIFESTS[manifest] = (None, frozenset(), frozenset())
+            _MANIFESTS[manifest] = Manifest(None, frozenset(), frozenset())
         else:
             declared = frozenset(
                 name
                 for name, condition in retrieve_exec_dependencies_with_conditions(root)
                 if evaluate_condition(condition)
             )
-            _MANIFESTS[manifest] = (
+            _MANIFESTS[manifest] = Manifest(
                 get_package_name(root),
                 declared,
                 parse_exceptions(root).ignored_deps,
+                declared_host(root),
             )
     return _MANIFESTS[manifest]
 
@@ -242,7 +280,7 @@ def _index(manifests: "list[str]") -> dict:
     """`package name -> package.xml`, for looking a source manifest up by name."""
     found = {}
     for manifest in manifests:
-        name = _read(manifest)[0]
+        name = _read(manifest).name
         if name:
             found[name] = manifest
     return found
@@ -259,7 +297,7 @@ def _owner(path: str, source: dict) -> Optional[str]:
     while True:
         manifest = os.path.join(directory, "package.xml")
         if os.path.isfile(manifest):
-            name = _read(manifest)[0]
+            name = _read(manifest).name
             return source.get(name, manifest) if name else manifest
         parent = os.path.dirname(directory)
         if parent == directory:
@@ -296,7 +334,7 @@ def _muted(package: str, scope: Scope, manifest: Optional[str]) -> bool:
     """Whether this package was asked to be left out, globally or by the manifest citing it."""
     if package in scope.ignored:
         return True
-    return manifest is not None and package in _read(manifest)[2]
+    return manifest is not None and package in _read(manifest).ignored
 
 
 def _first_mention(walk: Walk) -> dict:
@@ -317,8 +355,13 @@ def _undeclared(walk: Walk, scope: Scope, owners: dict) -> "list[Finding]":
         if manifest is None or _muted(one.package, scope, manifest):
             continue
 
-        name, declared, _ = _read(manifest)
-        if one.package == name or one.package in declared:
+        owner = _read(manifest)
+        satisfied = owner.declared
+        if manifest == scope.config_manifest:
+            # Its launch files describe what every host runs; each host's install set declares
+            # its own share. Without this the whole arrangement reads as missing.
+            satisfied = satisfied | scope.delegated
+        if one.package == owner.name or one.package in satisfied:
             continue
 
         if (manifest, one.package) in seen:
@@ -406,7 +449,7 @@ def _owner_name(manifest: Optional[str]) -> str:
     """
     if manifest is None:
         return "its own package"
-    return _read(manifest)[0] or os.path.basename(os.path.dirname(manifest))
+    return _read(manifest).name or os.path.basename(os.path.dirname(manifest))
 
 
 def _report(

--- a/package_xml_validation/check_launch_tree.py
+++ b/package_xml_validation/check_launch_tree.py
@@ -25,7 +25,9 @@ a workspace.
 """
 
 from pathlib import Path
+from types import MappingProxyType
 from typing import NamedTuple, Optional
+from collections.abc import Mapping
 import argparse
 import os
 import sys
@@ -144,11 +146,13 @@ class Scope(NamedTuple):
     """The manifest of the package holding `launch_manager_configs/`, the only one whose launch
     files may leave their dependencies to an install set."""
 
-    host_packages: dict = {}
+    # Read-only defaults: a NamedTuple's default is one object shared by every instance that
+    # omits the field, so a plain {} here would let one scope's contents leak into the next.
+    host_packages: "Mapping[str, set]" = MappingProxyType({})
     """`host -> packages its components launch`, so a reference nobody declared can be charged
     to the hosts that need it."""
 
-    install_sets: dict = {}
+    install_sets: "Mapping[str, str]" = MappingProxyType({})
     """`host -> the manifest claiming it`. A host missing here has no install set at all."""
 
     @classmethod

--- a/package_xml_validation/check_launch_tree.py
+++ b/package_xml_validation/check_launch_tree.py
@@ -44,7 +44,7 @@ from .helpers.formatter.dependency_queries import (
     get_package_name,
     retrieve_exec_dependencies_with_conditions,
 )
-from .helpers.launch_manager import declared_host, find_config_package
+from .helpers.launch_manager import declared_host, derive, find_config_package
 from .helpers.workspace import find_package_xml_files, find_workspace_root
 
 __all__ = [
@@ -94,6 +94,10 @@ class Finding(NamedTuple):
     launch_file: str = ""
     """For a dead include, the file the include named."""
 
+    hosts: tuple = ()
+    """For a reference no install set declares, the hosts that launch it - so the report can
+    name the manifests that should have declared it rather than the one it was written in."""
+
 
 def workspace_sources(paths: "list[str]") -> "list[str]":
     """The `<ws>/src` each path sits in, where there is one.
@@ -140,6 +144,13 @@ class Scope(NamedTuple):
     """The manifest of the package holding `launch_manager_configs/`, the only one whose launch
     files may leave their dependencies to an install set."""
 
+    host_packages: dict = {}
+    """`host -> packages its components launch`, so a reference nobody declared can be charged
+    to the hosts that need it."""
+
+    install_sets: dict = {}
+    """`host -> the manifest claiming it`. A host missing here has no install set at all."""
+
     @classmethod
     def of(
         cls,
@@ -159,17 +170,30 @@ class Scope(NamedTuple):
             index.update(_index(find_package_xml_files([root])))
 
         delegated: set = set()
+        install_sets: dict = {}
         for manifest in index.values():
-            if _read(manifest).host:
-                delegated.update(_read(manifest).declared)
+            read = _read(manifest)
+            if read.host:
+                delegated.update(read.declared)
+                install_sets.setdefault(read.host, manifest)
 
-        config = find_config_package(sorted(package_dirs_under(paths)))
+        # Deriving means walking every component's launch tree, so it is only worth doing once
+        # something has claimed a host - which is also the only case it can say anything about.
+        config = None
+        host_packages: dict = {}
+        if install_sets:
+            dirs = sorted(package_dirs_under(paths))
+            config = find_config_package(dirs)
+            host_packages = derive(dirs).packages
+
         return cls(
             index,
             fatal_under,
             ignored,
             frozenset(delegated),
             os.path.join(config, "package.xml") if config else None,
+            host_packages,
+            install_sets,
         )
 
     def severity_of(self, manifest: Optional[str]) -> str:
@@ -376,10 +400,28 @@ def _undeclared(walk: Walk, scope: Scope, owners: dict) -> "list[Finding]":
                 one.file,
                 one.line,
                 manifest,
+                hosts=_hosts_launching(one.package, scope, manifest),
             )
         )
 
     return findings
+
+
+def _hosts_launching(package: str, scope: Scope, manifest: str) -> tuple:
+    """The hosts whose components launch `package`, when install sets are in play.
+
+    Only for the configuration package: everywhere else the manifest a reference was written in
+    is the manifest that should declare it, and there is nothing to redirect.
+    """
+    if manifest != scope.config_manifest:
+        return ()
+    return tuple(
+        sorted(
+            host
+            for host, packages in scope.host_packages.items()
+            if package in packages
+        )
+    )
 
 
 def _dead(walk: Walk, scope: Scope, owners: dict, absent: set) -> "list[Finding]":
@@ -438,7 +480,7 @@ def _where(path: str, package_dir: str) -> str:
 
 #: Indent for the detail lines under a finding, and the width their labels are padded to.
 DETAIL = " " * 12
-LABEL = 9
+LABEL = 10
 
 
 def _owner_name(manifest: Optional[str]) -> str:
@@ -483,7 +525,12 @@ def _report(
             continue
         print()
         print(f"  {one.severity:<7} {_headline(one, uninstalled)}")
-        if one.kind == UNDECLARED and one.owner:
+        if one.kind == UNDECLARED and one.hosts:
+            for host in one.hosts:
+                print(
+                    f"{DETAIL}{'wanted by':<{LABEL}}{_install_set(host, scope, package_dir)}"
+                )
+        elif one.kind == UNDECLARED and one.owner:
             print(f"{DETAIL}{'manifest':<{LABEL}}{_where(one.owner, package_dir)}")
         print(
             f"{DETAIL}{'named in':<{LABEL}}{_where(one.file, package_dir)}:{one.line}"
@@ -506,6 +553,14 @@ def _report(
         )
 
 
+def _install_set(host: str, scope: Scope, package_dir: str) -> str:
+    """The manifest that should declare what `host` launches, or that there is none."""
+    manifest = scope.install_sets.get(host)
+    if manifest is None:
+        return f"{host} - no package claims this host, so nothing declares what it runs"
+    return f"{host} - {_where(manifest, package_dir)}"
+
+
 def _headline(one: Finding, uninstalled: set) -> str:
     if one.kind == NOT_INSTALLED:
         return f"{one.package} is not installed in this workspace"
@@ -514,6 +569,11 @@ def _headline(one: Finding, uninstalled: set) -> str:
         return f"{one.package} does not ship {one.launch_file}"
 
     absent = " (and is not installed here)" if one.package in uninstalled else ""
+    if one.hosts:
+        # Written in the configuration package, but an install set is what should declare it.
+        return (
+            f"{one.package} is not declared by any install set that launches it{absent}"
+        )
     return f"{one.package} is not declared by {_owner_name(one.owner)}{absent}"
 
 

--- a/package_xml_validation/helpers/launch_manager.py
+++ b/package_xml_validation/helpers/launch_manager.py
@@ -1,0 +1,268 @@
+"""Which packages each host runs, derived from a launch-manager configuration.
+
+A launch-manager repository states twice, in two machine-readable places, what a host runs:
+`launch_manager_configs/*.yaml` assigns a component to a host, and the component's own definition
+names the launch file it starts. Following that launch file gives every package the host needs.
+
+That makes a per-host dependency set derivable rather than hand-maintained, which matters when the
+launch files live in one package and the dependencies are declared in a sibling *install set* per
+host - the shape a workspace takes when some of its machines are too small to install everything.
+
+The result is a **lower bound**. A controller plugin named only by class in a parameter file, or a
+package passed as an argument to a generic component, is named nowhere this can reach. Callers may
+add what is derived; they must never remove what is not.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import lxml.etree as ET
+import yaml
+
+from .find_launch_dependencies import default_share_lookup, scan_from
+from .formatter.dependency_queries import retrieve_exec_dependencies
+
+if TYPE_CHECKING:
+    from .package_types import XmlElement
+
+#: Where a repository keeps the files this reads.
+CONFIG_DIR = "launch_manager_configs"
+COMPONENT_DIR = "launch_manager_components"
+
+#: The `<export>` child by which a package claims to be a host's install set.
+HOST_EXPORT = "launch_manager_host"
+
+#: The package that ships components shared between robots. Components a configuration names but
+#: the repository does not define are looked up here.
+SHARED_COMPONENTS = "launch_manager_common_components"
+
+
+@dataclass
+class HostDependencies:
+    """What each host runs, and how much of the question went unanswered."""
+
+    packages: dict[str, set[str]] = field(default_factory=dict)
+    """`host -> packages its components need`."""
+
+    unresolved: list[str] = field(default_factory=list)
+    """Components named by a configuration whose definition was not found."""
+
+    problems: list[str] = field(default_factory=list)
+    """Why a derivation is missing or incomplete, in words a reader can act on."""
+
+    @property
+    def complete(self) -> bool:
+        """Whether every component was read.
+
+        False means the sets below are short by an unknown amount, so they may be reported but
+        must not be filled in - a partial derivation that looks complete is worse than none.
+        """
+        return not self.unresolved and not self.problems
+
+
+def declared_host(root: XmlElement) -> str | None:
+    """The host a package claims to be the install set for, or None.
+
+    `<export><launch_manager_host>athena-gripper</launch_manager_host></export>`. The export
+    section is the sanctioned place for a tool's own metadata: the schema check only inspects
+    top-level children, and the build-type step leaves other export children alone.
+    """
+    export = root.find("export")
+    if export is None:
+        return None
+    element = export.find(HOST_EXPORT)
+    if element is None or not element.text:
+        return None
+    return element.text.strip() or None
+
+
+def find_config_package(package_dirs: list[str]) -> str | None:
+    """The package holding the launch-manager configuration, if exactly one does."""
+    holders = [
+        one for one in package_dirs if os.path.isdir(os.path.join(one, CONFIG_DIR))
+    ]
+    return holders[0] if len(holders) == 1 else None
+
+
+def derive(package_dirs: list[str]) -> HostDependencies:
+    """`host -> packages` for the launch-manager configuration found under `package_dirs`."""
+    holders = [
+        one for one in package_dirs if os.path.isdir(os.path.join(one, CONFIG_DIR))
+    ]
+
+    if not holders:
+        return HostDependencies(
+            problems=[f"no package holds a {CONFIG_DIR}/ directory"]
+        )
+    if len(holders) > 1:
+        names = ", ".join(sorted(os.path.basename(one) for one in holders))
+        return HostDependencies(
+            problems=[
+                f"{len(holders)} packages hold a {CONFIG_DIR}/ directory ({names}); "
+                "cannot tell which configuration describes the hosts"
+            ]
+        )
+
+    config_package = holders[0]
+    definitions, shared_problem = _component_definitions(config_package)
+
+    derived = HostDependencies()
+    if shared_problem:
+        derived.problems.append(shared_problem)
+
+    own_name = os.path.basename(os.path.abspath(config_package))
+    for name, hosts in _assignments(config_package, derived).items():
+        definition = definitions.get(name)
+        if definition is None:
+            derived.unresolved.append(name)
+            continue
+        # scan_from follows the component's `package:` + `launch_file:` edge into the launch
+        # tree, so this picks up what the launch file pulls in, not only what the component names.
+        found = set(scan_from(definition).packages) - {own_name}
+        for host in hosts:
+            derived.packages.setdefault(host, set()).update(found)
+
+    return derived
+
+
+def _assignments(
+    config_package: str, derived: HostDependencies
+) -> dict[str, list[str]]:
+    """`component -> hosts`, unioned over every configuration in the package.
+
+    Unioned rather than read one file at a time: a robot may be started with any of them, so a
+    package needed by only one configuration is still a package the host needs installed.
+    """
+    found: dict[str, list[str]] = {}
+
+    for path in sorted(glob.glob(os.path.join(config_package, CONFIG_DIR, "*.y*ml"))):
+        try:
+            with open(path, encoding="utf-8") as f:
+                document = yaml.safe_load(f) or {}
+        except (OSError, yaml.YAMLError) as e:
+            derived.problems.append(f"{os.path.basename(path)} could not be read: {e}")
+            continue
+
+        if not isinstance(document, dict):
+            continue
+
+        for entry in document.get("components") or []:
+            if not isinstance(entry, dict) or not entry.get("name"):
+                continue
+            hosts = entry.get("hosts", entry.get("host"))
+            hosts = [hosts] if isinstance(hosts, str) else hosts
+            if not isinstance(hosts, list):
+                continue
+            on = found.setdefault(str(entry["name"]), [])
+            on.extend(str(one) for one in hosts if str(one) not in on)
+
+    return found
+
+
+def _component_definitions(config_package: str) -> tuple[dict[str, str], str | None]:
+    """`component name -> its definition file`, from the repository then the shared library.
+
+    The repository wins, so a robot may override a shared component. Both trees are searched to
+    any depth; components are routinely grouped into subdirectories.
+    """
+    found: dict[str, str] = {}
+
+    share = default_share_lookup(SHARED_COMPONENTS)
+    problem = None
+    if share is None:
+        problem = (
+            f"{SHARED_COMPONENTS} is not installed, so components it defines cannot be read - "
+            "source the workspace to complete the derivation"
+        )
+    else:
+        _collect(share, found)
+
+    # Second, so the repository's own definitions overwrite the shared ones.
+    _collect(os.path.join(config_package, COMPONENT_DIR), found)
+
+    return found, problem
+
+
+def _collect(root: str, into: dict[str, str]) -> None:
+    for path in sorted(glob.glob(os.path.join(root, "**", "*.y*ml"), recursive=True)):
+        into[os.path.splitext(os.path.basename(path))[0]] = path
+
+
+# ── What one run needs to know about the install sets in front of it ─────────────────────
+
+
+@dataclass
+class LaunchManagerContext:
+    """The install sets in this run, and what each host turns out to need."""
+
+    hosts: HostDependencies
+    config_package: str
+    delegated: frozenset[str]
+    """Every dependency declared by an install set.
+
+    A launch file in the configuration package may name any of these: they are declared, just
+    not by the package the launch file lives in. Together they are what stops the whole
+    arrangement reading as one long list of missing dependencies.
+    """
+
+    claimed: frozenset[str]
+    """The hosts some package claims. A host in a configuration but not here has no install
+    set, so nothing declares what it runs."""
+
+    @property
+    def unclaimed(self) -> dict[str, set[str]]:
+        return {
+            host: packages
+            for host, packages in self.hosts.packages.items()
+            if host not in self.claimed
+        }
+
+
+def context_for(package_xml_files: list[str]) -> LaunchManagerContext | None:
+    """Read the install sets in this run, or None if there are none.
+
+    Returns None the moment no manifest claims a host, before parsing anything or walking a
+    single launch file - a repository that does not use this pays only for a substring search.
+    """
+    claiming = [one for one in package_xml_files if _mentions_host_export(one)]
+    if not claiming:
+        return None
+
+    # A manifest that is unreadable here is unreadable everywhere, and the schema step reports
+    # it - so a parse failure is skipped rather than raised a second time.
+    delegated: set[str] = set()
+    claimed: set[str] = set()
+    for path in claiming:
+        try:
+            parser = ET.XMLParser(no_network=True, resolve_entities=False)
+            root = ET.parse(path, parser).getroot()
+        except (OSError, ET.XMLSyntaxError):
+            continue
+        host = declared_host(root)
+        if host is None:
+            continue
+        claimed.add(host)
+        delegated.update(retrieve_exec_dependencies(root))
+
+    package_dirs = sorted({os.path.dirname(one) for one in package_xml_files})
+    derived = derive(package_dirs)
+    config_package = find_config_package(package_dirs) or ""
+
+    return LaunchManagerContext(
+        hosts=derived,
+        config_package=config_package,
+        delegated=frozenset(delegated),
+        claimed=frozenset(claimed),
+    )
+
+
+def _mentions_host_export(package_xml: str) -> bool:
+    try:
+        with open(package_xml, encoding="utf-8", errors="replace") as f:
+            return HOST_EXPORT in f.read()
+    except OSError:
+        return False

--- a/package_xml_validation/helpers/validation_steps/__init__.py
+++ b/package_xml_validation/helpers/validation_steps/__init__.py
@@ -10,6 +10,7 @@ from .buildtool_step import BuildToolDependStep
 from .cmake_comparison_step import CMakeComparisonStep
 from .dependency_exclusivity_step import DependencyExclusivityStep
 from .formatter_step import FormatterValidationStep
+from .host_dependency_step import HostDependencyStep
 from .launch_dependency_step import LaunchDependencyStep
 from .manifest_schema_step import ManifestSchemaStep
 from .member_of_group_step import MemberOfGroupStep
@@ -22,6 +23,7 @@ __all__ = [
     "CMakeComparisonStep",
     "DependencyExclusivityStep",
     "FormatterValidationStep",
+    "HostDependencyStep",
     "LaunchDependencyStep",
     "ManifestSchemaStep",
     "MemberOfGroupStep",

--- a/package_xml_validation/helpers/validation_steps/host_dependency_step.py
+++ b/package_xml_validation/helpers/validation_steps/host_dependency_step.py
@@ -61,6 +61,13 @@ class HostDependencyStep(ValidationStep):
             return result
 
         if host not in self.hosts.packages:
+            if not self.hosts.complete:
+                # The configuration could not be read, so the host may well be in it. Saying
+                # it is not would send the reader to fix a manifest that is already right.
+                result.warnings.append(
+                    f"Cannot tell what host '{host}' runs: {self._why_incomplete()}"
+                )
+                return result
             known = ", ".join(sorted(self.hosts.packages)) or "none"
             result.errors.append(
                 f"{self.package_name}/package.xml claims host '{host}', which no "

--- a/package_xml_validation/helpers/validation_steps/host_dependency_step.py
+++ b/package_xml_validation/helpers/validation_steps/host_dependency_step.py
@@ -1,0 +1,131 @@
+"""Per-host dependency validation for launch-manager install sets."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..launch_manager import HostDependencies, declared_host
+from ..logger import get_logger
+from ._base import ValidationConfig, ValidationResult, ValidationStep
+
+if TYPE_CHECKING:
+    from ..exception_parser import DependencyExceptions
+    from ..package_types import XmlElement
+    from ..pkg_xml_formatter import PackageXmlFormatter
+    from ..rosdep_validator import RosdepValidator
+
+
+class HostDependencyStep(ValidationStep):
+    """Check an install set against what its host actually runs.
+
+    A package claiming a host with ``<export><launch_manager_host>`` is the manifest for
+    everything that host launches, even though the launch files live elsewhere. What the host
+    runs is derived by following each of its components into the launch tree, so this step
+    compares that derivation against what the manifest declares.
+
+    Additive only. The derivation is a lower bound - a controller plugin named by class in a
+    parameter file, or a package handed to a generic component as an argument, is named nowhere
+    it can reach - so a declared dependency it did not derive is left alone and not reported.
+    Removing one would uninstall something the robot needs.
+
+    Nothing is filled from an incomplete derivation. A component that could not be read means
+    the host's set is short by an unknown amount, and quietly reporting a shorter list as
+    complete is worse than reporting nothing.
+    """
+
+    name = "Host dependency check"
+
+    def __init__(
+        self,
+        config: ValidationConfig,
+        formatter: PackageXmlFormatter,
+        rosdep_validator: RosdepValidator | None,
+        package_name: str | None,
+        hosts: HostDependencies,
+        exceptions: DependencyExceptions | None = None,
+    ) -> None:
+        """Initialize the per-host dependency validation step."""
+        super().__init__(config)
+        self.formatter = formatter
+        self.rosdep_validator = rosdep_validator
+        self.package_name = package_name
+        self.hosts = hosts
+        self.exceptions = exceptions
+        self._logger = get_logger(__name__)
+
+    def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
+        """Compare this install set against the packages its host launches."""
+        result = ValidationResult(root=root)
+        host = declared_host(root)
+        if host is None:
+            return result
+
+        if host not in self.hosts.packages:
+            known = ", ".join(sorted(self.hosts.packages)) or "none"
+            result.errors.append(
+                f"{self.package_name}/package.xml claims host '{host}', which no "
+                f"launch-manager configuration mentions. Hosts in the configuration: {known}."
+            )
+            result.valid = False
+            return result
+
+        declared = set(self.formatter.retrieve_exec_dependencies(root))
+        missing = sorted(
+            one
+            for one in self.hosts.packages[host]
+            if one not in declared
+            and one != self.package_name
+            and not (self.exceptions and self.exceptions.is_ignored(one))
+        )
+        if not missing:
+            return result
+
+        if not self.hosts.complete:
+            result.warnings.append(
+                f"Not filling {len(missing)} dependency/ies for host '{host}': "
+                f"{self._why_incomplete()}"
+            )
+            return result
+
+        return self._report_or_fill(result, root, host, missing)
+
+    def _why_incomplete(self) -> str:
+        reasons = list(self.hosts.problems)
+        if self.hosts.unresolved:
+            names = ", ".join(sorted(set(self.hosts.unresolved)))
+            reasons.append(f"no definition found for component(s) {names}")
+        return "; ".join(reasons)
+
+    def _report_or_fill(
+        self,
+        result: ValidationResult,
+        root: XmlElement,
+        host: str,
+        missing: list[str],
+    ) -> ValidationResult:
+        if self.config.check_only or not self.config.auto_fill_missing_deps:
+            result.errors.append(
+                f"Host '{host}' launches {len(missing)} package(s) that "
+                f"{self.package_name}/package.xml does not declare: {', '.join(missing)}"
+            )
+            result.valid = False
+            return result
+
+        if self.config.check_rosdeps and self.rosdep_validator is not None:
+            invalid = self.rosdep_validator.check_rosdeps_and_local_pkgs(missing)
+            if invalid:
+                result.critical_errors.append(
+                    f"Cannot auto-fill host dependencies that resolve to nothing: "
+                    f"{', '.join(sorted(invalid))}"
+                )
+                result.valid = False
+                return result
+
+        self.formatter.add_dependencies(root, missing, "exec_depend")
+        result.warnings.append(
+            f"Auto-filling {len(missing)} <exec_depend> entries for host '{host}' in "
+            f"{self.package_name}/package.xml: {', '.join(missing)}"
+        )
+        result.changed = True
+        result.valid = False
+        return result

--- a/package_xml_validation/helpers/validation_steps/launch_dependency_step.py
+++ b/package_xml_validation/helpers/validation_steps/launch_dependency_step.py
@@ -34,6 +34,13 @@ class LaunchDependencyStep(ValidationStep):
     be installed at runtime in environments where its condition is
     False. Disable with ``--ignore-conditions``.
 
+    ``delegated`` names dependencies declared by a launch-manager install
+    set rather than here. A package holding the launch files for several
+    hosts declares almost nothing itself, because each host installs only
+    what it runs; without this every one of those references would read as
+    missing. Delegated references are neither reported nor auto-filled -
+    the install set owns them, and :class:`HostDependencyStep` checks it.
+
     When ``auto_fill_missing_deps=True``, missing deps are validated
     against rosdep before being added — names that don't resolve are
     flagged rather than auto-filled. When ``check_only=True`` or
@@ -49,6 +56,7 @@ class LaunchDependencyStep(ValidationStep):
         rosdep_validator: RosdepValidator | None,
         package_name: str | None,
         exceptions: DependencyExceptions | None = None,
+        delegated: frozenset[str] = frozenset(),
     ) -> None:
         """Initialize launch dependency validation step."""
         super().__init__(config)
@@ -56,6 +64,7 @@ class LaunchDependencyStep(ValidationStep):
         self.rosdep_validator = rosdep_validator
         self.package_name = package_name
         self.exceptions = exceptions or DependencyExceptions()
+        self.delegated = delegated
         self._logger = get_logger(__name__)
 
     def perform_check(self, root: XmlElement, xml_file: str) -> ValidationResult:
@@ -108,6 +117,7 @@ class LaunchDependencyStep(ValidationStep):
             for dep in launch_deps
             if dep not in xml_deps
             and dep != self.package_name
+            and dep not in self.delegated
             and not self.exceptions.is_ignored(dep)
         ]
         if not missing_deps:

--- a/package_xml_validation/package_xml_validator.py
+++ b/package_xml_validation/package_xml_validator.py
@@ -14,6 +14,7 @@ import lxml.etree as ET
 
 from .helpers.cmake_parsers import _DEFAULT_CMAKE_KEYS_NO_ROSDEP
 from .helpers.exception_parser import DependencyExceptions, parse_exceptions
+from .helpers.launch_manager import LaunchManagerContext, context_for
 from .helpers.logger import get_logger
 from .helpers.pkg_xml_formatter import PackageXmlFormatter
 from .helpers.rosdep_validator import RosdepValidator
@@ -23,6 +24,7 @@ from .helpers.validation_steps import (
     CMakeComparisonStep,
     DependencyExclusivityStep,
     FormatterValidationStep,
+    HostDependencyStep,
     LaunchDependencyStep,
     ManifestSchemaStep,
     MemberOfGroupStep,
@@ -92,6 +94,7 @@ class PackageXmlValidator:
         self.excluded_packages = (
             frozenset(excluded_packages) if excluded_packages else frozenset()
         )
+        self.launch_manager: LaunchManagerContext | None = None
         self.missing_deps_only = missing_deps_only
         self.ignore_formatting_errors = ignore_formatting_errors
         self.check_only = check_only or missing_deps_only or ignore_formatting_errors
@@ -184,8 +187,21 @@ class PackageXmlValidator:
                 self.rosdep_validator if self.check_rosdeps else None,
                 package_name,
                 exceptions,
+                delegated=self._delegated_for(xml_file),
             ),
         ]
+
+        if self.launch_manager is not None:
+            steps.append(
+                HostDependencyStep(
+                    self.validation_config,
+                    self.formatter,
+                    self.rosdep_validator if self.check_rosdeps else None,
+                    package_name,
+                    self.launch_manager.hosts,
+                    exceptions,
+                )
+            )
 
         if not self.missing_deps_only:
             steps.extend(
@@ -247,6 +263,39 @@ class PackageXmlValidator:
                 kept.append(xml_file)
         return kept
 
+    def _delegated_for(self, xml_file: str) -> frozenset[str]:
+        """Dependencies this package's launch files may leave to a launch-manager install set.
+
+        Only the package holding the configuration gets this. Its launch files describe what
+        every host runs, while each host's install set declares its own share; without the
+        allowance every one of those references reads as missing here.
+        """
+        if self.launch_manager is None:
+            return frozenset()
+        if os.path.dirname(os.path.abspath(xml_file)) != os.path.abspath(
+            self.launch_manager.config_package
+        ):
+            return frozenset()
+        return self.launch_manager.delegated
+
+    def _report_hosts_without_an_install_set(self) -> None:
+        """A host the configuration launches on, that no package declares dependencies for.
+
+        Nothing installs what it runs, and no per-package check can notice: the gap is the
+        absence of a package, so it has to be reported from the run rather than from a file.
+        """
+        if self.launch_manager is None:
+            return
+        for host, packages in sorted(self.launch_manager.unclaimed.items()):
+            self.logger.error(
+                f"No package claims host '{host}', so nothing declares the "
+                f"{len(packages)} package(s) it launches: {', '.join(sorted(packages))}. "
+                f"Add <export><launch_manager_host>{host}</launch_manager_host></export> to "
+                "the package that installs them.",
+                extra={"flush_left": True},
+            )
+            self.all_valid = False
+
     def check_and_format_files(self, package_xml_files: Iterable[str]) -> bool:
         """Validate and optionally format a list of package.xml files.
 
@@ -259,7 +308,10 @@ class PackageXmlValidator:
         """
         self.all_valid = True
         encountered_unresolvable_error = False
-        for xml_file in self._without_excluded(package_xml_files):
+        remaining = self._without_excluded(package_xml_files)
+        self.launch_manager = context_for(remaining)
+
+        for xml_file in remaining:
             self.xml_valid = True
             pkg_name = os.path.basename(os.path.dirname(xml_file))
             self.logger.info(f"Processing {pkg_name}...", extra={"flush_left": True})
@@ -320,6 +372,8 @@ class PackageXmlValidator:
                 )
 
             self.all_valid &= self.xml_valid
+
+        self._report_hosts_without_an_install_set()
         # Final result messages
         if not self.all_valid and self.check_only:
             self.logger.warning(

--- a/package_xml_validation/package_xml_validator.py
+++ b/package_xml_validation/package_xml_validator.py
@@ -278,15 +278,20 @@ class PackageXmlValidator:
             return frozenset()
         return self.launch_manager.delegated
 
-    def _report_hosts_without_an_install_set(self) -> None:
+    def _report_hosts_without_an_install_set(self) -> bool:
         """A host the configuration launches on, that no package declares dependencies for.
 
         Nothing installs what it runs, and no per-package check can notice: the gap is the
         absence of a package, so it has to be reported from the run rather than from a file.
+
+        Returns whether any were found. Creating the missing package is not something this can
+        do, so the caller counts it among the unresolvable errors - otherwise a run whose only
+        finding is this one signs off with "corrected successfully".
         """
         if self.launch_manager is None:
-            return
-        for host, packages in sorted(self.launch_manager.unclaimed.items()):
+            return False
+        unclaimed = sorted(self.launch_manager.unclaimed.items())
+        for host, packages in unclaimed:
             self.logger.error(
                 f"No package claims host '{host}', so nothing declares the "
                 f"{len(packages)} package(s) it launches: {', '.join(sorted(packages))}. "
@@ -295,6 +300,7 @@ class PackageXmlValidator:
                 extra={"flush_left": True},
             )
             self.all_valid = False
+        return bool(unclaimed)
 
     def check_and_format_files(self, package_xml_files: Iterable[str]) -> bool:
         """Validate and optionally format a list of package.xml files.
@@ -373,7 +379,7 @@ class PackageXmlValidator:
 
             self.all_valid &= self.xml_valid
 
-        self._report_hosts_without_an_install_set()
+        encountered_unresolvable_error |= self._report_hosts_without_an_install_set()
         # Final result messages
         if not self.all_valid and self.check_only:
             self.logger.warning(

--- a/tests/test_check_launch_tree.py
+++ b/tests/test_check_launch_tree.py
@@ -311,6 +311,72 @@ class TestWhatItFinds(LaunchTreeTestCase):
         self.assertEqual([], findings)
 
 
+class TestLaunchManagerInstallSets(LaunchTreeTestCase):
+    """A package holding the launch files for several hosts declares almost nothing itself.
+
+    Each host installs only what it runs, so the dependencies are declared by sibling install
+    sets. Without that allowance every reference in the shared package reads as missing.
+    """
+
+    def install_set(self, name, host, deps):
+        directory = os.path.join(self.root, name)
+        body = "".join(f"<exec_depend>{one}</exec_depend>" for one in deps)
+        self.write(
+            os.path.join(directory, "package.xml"),
+            f'<package format="3"><name>{name}</name>{body}'
+            f"<export><launch_manager_host>{host}</launch_manager_host></export></package>",
+        )
+        return directory
+
+    def setUp(self):
+        super().setUp()
+        self.install("driver", "launch/driver.launch.yaml", "launch: []\n")
+        self.config_pkg = self.package(
+            "app",
+            "launch_manager_configs/default.yaml",
+            "components:\n  - name: a_driver\n    hosts: gripper\n",
+        )
+        self.write_into(
+            self.config_pkg,
+            "launch_manager_components/a_driver.yaml",
+            "launch:\n  package: driver\n  launch_file: driver.launch.yaml\n",
+        )
+
+    def test_a_reference_an_install_set_declares_is_not_a_finding(self):
+        self.install_set("app_gripper", "gripper", ["driver"])
+
+        _, findings = check(self.config_pkg, scope=Scope.of([self.root]))
+
+        self.assertEqual([], of_kind(findings, UNDECLARED))
+
+    def test_a_reference_nobody_declares_still_is(self):
+        """The allowance is for dependencies declared elsewhere, not for switching the check
+        off."""
+        self.install_set("app_gripper", "gripper", [])
+
+        _, findings = check(self.config_pkg, scope=Scope.of([self.root]))
+
+        self.assertEqual(
+            ["driver"], [one.package for one in of_kind(findings, UNDECLARED)]
+        )
+
+    def test_an_ordinary_package_may_not_borrow_the_allowance(self):
+        """Only the package holding the configuration delegates; a package that merely sits in
+        the same repository still declares its own dependencies."""
+        self.install_set("app_gripper", "gripper", ["driver"])
+        other = self.package(
+            "other",
+            "launch/other.launch.yaml",
+            "launch:\n  - node:\n      pkg: driver\n",
+        )
+
+        _, findings = check(other, scope=Scope.of([self.root]))
+
+        self.assertEqual(
+            ["driver"], [one.package for one in of_kind(findings, UNDECLARED)]
+        )
+
+
 class TestWhoIsHeldResponsible(LaunchTreeTestCase):
     """A finding is only fatal when the package that owns the offending file is fixable."""
 

--- a/tests/test_check_launch_tree.py
+++ b/tests/test_check_launch_tree.py
@@ -3,6 +3,7 @@
 import contextlib
 import io
 import os
+import re
 import tempfile
 import unittest
 from unittest import mock
@@ -328,6 +329,14 @@ class TestLaunchManagerInstallSets(LaunchTreeTestCase):
         )
         return directory
 
+    def report_of(self, package_dir):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            with mock.patch("sys.argv", ["check-launch-tree", self.root]):
+                with contextlib.suppress(SystemExit):
+                    main()
+        return out.getvalue()
+
     def setUp(self):
         super().setUp()
         self.install("driver", "launch/driver.launch.yaml", "launch: []\n")
@@ -359,6 +368,45 @@ class TestLaunchManagerInstallSets(LaunchTreeTestCase):
         self.assertEqual(
             ["driver"], [one.package for one in of_kind(findings, UNDECLARED)]
         )
+
+    def test_a_reference_nobody_declares_names_the_install_set_that_wants_it(self):
+        """The reference is written in the configuration package, but an install set is what
+        should declare it - so blaming the file it was written in points at the wrong manifest."""
+        install_set = self.install_set("app_gripper", "gripper", [])
+
+        _, findings = check(self.config_pkg, scope=Scope.of([self.root]))
+
+        undeclared = of_kind(findings, UNDECLARED)[0]
+        self.assertEqual(("gripper",), undeclared.hosts)
+
+        report = self.report_of(self.config_pkg)
+        self.assertIn("is not declared by any install set that launches it", report)
+        self.assertIn(f"gripper - {os.path.join(install_set, 'package.xml')}", report)
+
+    def test_a_host_with_no_install_set_is_named_as_such(self):
+        self.write(
+            os.path.join(self.config_pkg, "launch_manager_configs", "default.yaml"),
+            "components:\n  - name: a_driver\n    hosts: jetson\n",
+        )
+        self.install_set("app_gripper", "gripper", [])
+
+        report = self.report_of(self.config_pkg)
+
+        self.assertIn("jetson - no package claims this host", report)
+
+    def test_an_ordinary_package_gets_no_host_attribution(self):
+        """Outside the configuration package the manifest a reference was written in is the one
+        that should declare it, so there is nothing to redirect."""
+        self.install_set("app_gripper", "gripper", [])
+        other = self.package(
+            "other",
+            "launch/other.launch.yaml",
+            "launch:\n  - node:\n      pkg: driver\n",
+        )
+
+        _, findings = check(other, scope=Scope.of([self.root]))
+
+        self.assertEqual((), of_kind(findings, UNDECLARED)[0].hosts)
 
     def test_an_ordinary_package_may_not_borrow_the_allowance(self):
         """Only the package holding the configuration delegates; a package that merely sits in
@@ -708,9 +756,12 @@ class TestWhatItPrints(LaunchTreeTestCase):
         report = self.report_for(pkg)
 
         self.assertIn("undeclared_by_aggregator is not declared by aggregator", report)
-        self.assertIn(
-            f"manifest {os.path.join(self.prefix, 'share', 'aggregator', 'package.xml')}",
+        self.assertRegex(
             report,
+            r"manifest\s+"
+            + re.escape(
+                os.path.join(self.prefix, "share", "aggregator", "package.xml")
+            ),
         )
         self.assertIn("named in", report)
 

--- a/tests/test_check_launch_tree.py
+++ b/tests/test_check_launch_tree.py
@@ -383,6 +383,14 @@ class TestLaunchManagerInstallSets(LaunchTreeTestCase):
         self.assertIn("is not declared by any install set that launches it", report)
         self.assertIn(f"gripper - {os.path.join(install_set, 'package.xml')}", report)
 
+    def test_scope_defaults_are_not_shared_between_instances(self):
+        """A NamedTuple default is one object for every instance that omits the field, so a
+        plain dict here would let one scope's contents leak into the next."""
+        with self.assertRaises(TypeError):
+            Scope({}, (), frozenset()).host_packages["leaked"] = set()
+
+        self.assertEqual({}, dict(Scope({}, (), frozenset()).host_packages))
+
     def test_a_host_with_no_install_set_is_named_as_such(self):
         self.write(
             os.path.join(self.config_pkg, "launch_manager_configs", "default.yaml"),

--- a/tests/test_host_dependency_step.py
+++ b/tests/test_host_dependency_step.py
@@ -1,0 +1,166 @@
+"""`HostDependencyStep`: an install set checked against what its host actually launches."""
+
+import unittest
+import unittest.mock
+
+import lxml.etree as ET
+
+from package_xml_validation.helpers.launch_manager import HostDependencies
+from package_xml_validation.helpers.pkg_xml_formatter import PackageXmlFormatter
+from package_xml_validation.helpers.validation_steps import (
+    HostDependencyStep,
+    ValidationConfig,
+)
+
+
+def config(**overrides):
+    defaults = {
+        "check_only": False,
+        "auto_fill_missing_deps": True,
+        "check_rosdeps": False,
+        "compare_with_cmake": False,
+        "strict_cmake_checking": False,
+        "missing_deps_only": False,
+        "ignore_formatting_errors": False,
+    }
+    defaults.update(overrides)
+    return ValidationConfig(**defaults)
+
+
+def manifest(name, host=None, deps=()):
+    body = "".join(f"<exec_depend>{one}</exec_depend>" for one in deps)
+    export = (
+        f"<export><build_type>ament_cmake</build_type>"
+        f"<launch_manager_host>{host}</launch_manager_host></export>"
+        if host
+        else ""
+    )
+    return ET.fromstring(
+        f'<package format="3"><name>{name}</name>{body}{export}</package>'.encode()
+    )
+
+
+def step(hosts, **overrides):
+    return HostDependencyStep(
+        config(**overrides),
+        PackageXmlFormatter(),
+        None,
+        "install_set",
+        hosts,
+    )
+
+
+def declared(root):
+    return [one.text for one in root if one.tag == "exec_depend"]
+
+
+class TestAnInstallSet(unittest.TestCase):
+    HOSTS = HostDependencies(packages={"gripper": {"driver_a", "driver_b"}})
+
+    def test_a_package_the_host_launches_and_it_does_not_declare_is_an_error(self):
+        root = manifest("install_set", host="gripper", deps=["driver_a"])
+
+        result = step(self.HOSTS, check_only=True).perform_check(root, "package.xml")
+
+        self.assertFalse(result.valid)
+        self.assertIn("driver_b", result.errors[0])
+
+    def test_auto_fill_adds_it(self):
+        root = manifest("install_set", host="gripper", deps=["driver_a"])
+
+        result = step(self.HOSTS).perform_check(root, "package.xml")
+
+        self.assertTrue(result.changed)
+        self.assertEqual(["driver_a", "driver_b"], sorted(declared(result.root)))
+
+    def test_a_declared_package_it_could_not_derive_is_left_alone(self):
+        """Controller plugins and packages passed to a component as arguments are named
+        nowhere the walk reaches. Removing them would uninstall something the robot needs, and
+        reporting them would be noise."""
+        root = manifest(
+            "install_set",
+            host="gripper",
+            deps=["driver_a", "driver_b", "a_controller_plugin"],
+        )
+
+        result = step(self.HOSTS, check_only=True).perform_check(root, "package.xml")
+
+        self.assertTrue(result.valid)
+        self.assertEqual([], result.errors)
+        self.assertIn("a_controller_plugin", declared(result.root))
+
+    def test_a_package_with_no_host_export_is_not_this_step_s_business(self):
+        root = manifest("ordinary", deps=[])
+
+        result = step(self.HOSTS, check_only=True).perform_check(root, "package.xml")
+
+        self.assertTrue(result.valid)
+        self.assertEqual([], result.errors)
+
+    def test_it_does_not_demand_a_dependency_on_itself(self):
+        hosts = HostDependencies(packages={"gripper": {"install_set", "driver_a"}})
+        root = manifest("install_set", host="gripper", deps=["driver_a"])
+
+        result = step(hosts, check_only=True).perform_check(root, "package.xml")
+
+        self.assertTrue(result.valid)
+
+
+class TestWhenItCannotBeSure(unittest.TestCase):
+    def test_a_host_no_configuration_mentions_is_an_error(self):
+        """Otherwise a typo in the export silently switches the check off for that package."""
+        hosts = HostDependencies(packages={"gripper": {"driver_a"}})
+        root = manifest("install_set", host="grippr")
+
+        result = step(hosts, check_only=True).perform_check(root, "package.xml")
+
+        self.assertFalse(result.valid)
+        self.assertIn("grippr", result.errors[0])
+        self.assertIn("gripper", result.errors[0])
+
+    def test_an_incomplete_derivation_never_fills(self):
+        """The set is short by an unknown amount, so filling from it would write a manifest
+        that looks complete and is not."""
+        hosts = HostDependencies(
+            packages={"gripper": {"driver_a"}}, unresolved=["a_component"]
+        )
+        root = manifest("install_set", host="gripper")
+
+        result = step(hosts).perform_check(root, "package.xml")
+
+        self.assertFalse(result.changed)
+        self.assertEqual([], declared(result.root))
+        self.assertIn("a_component", result.warnings[0])
+
+    def test_a_derived_name_rosdep_cannot_resolve_is_not_written(self):
+        """A component naming something that is not a package would otherwise put an
+        unresolvable key into a manifest, and rosdep would fail on every machine."""
+        hosts = HostDependencies(packages={"gripper": {"not_a_real_package"}})
+        rosdep = unittest.mock.MagicMock()
+        rosdep.check_rosdeps_and_local_pkgs.return_value = ["not_a_real_package"]
+        under_test = HostDependencyStep(
+            config(check_rosdeps=True),
+            PackageXmlFormatter(),
+            rosdep,
+            "install_set",
+            hosts,
+        )
+        root = manifest("install_set", host="gripper")
+
+        result = under_test.perform_check(root, "package.xml")
+
+        self.assertFalse(result.changed)
+        self.assertEqual([], declared(result.root))
+        self.assertIn("not_a_real_package", result.critical_errors[0])
+
+    def test_an_incomplete_derivation_says_why(self):
+        hosts = HostDependencies(
+            packages={"gripper": {"driver_a"}},
+            problems=["launch_manager_common_components is not installed"],
+        )
+        root = manifest("install_set", host="gripper")
+
+        result = step(hosts).perform_check(root, "package.xml")
+
+        self.assertFalse(result.changed)
+        self.assertIn("not installed", result.warnings[0])

--- a/tests/test_host_dependency_step.py
+++ b/tests/test_host_dependency_step.py
@@ -118,6 +118,21 @@ class TestWhenItCannotBeSure(unittest.TestCase):
         self.assertIn("grippr", result.errors[0])
         self.assertIn("gripper", result.errors[0])
 
+    def test_an_unknown_host_is_only_an_error_once_the_configuration_was_read(self):
+        """When the derivation failed the host may well be in a configuration nobody could
+        read, and saying it is not sends the reader to fix a manifest that is already right."""
+        hosts = HostDependencies(
+            packages={},
+            problems=["2 packages hold a launch_manager_configs/ directory"],
+        )
+        root = manifest("install_set", host="gripper")
+
+        result = step(hosts, check_only=True).perform_check(root, "package.xml")
+
+        self.assertTrue(result.valid)
+        self.assertEqual([], result.errors)
+        self.assertIn("Cannot tell what host 'gripper' runs", result.warnings[0])
+
     def test_an_incomplete_derivation_never_fills(self):
         """The set is short by an unknown amount, so filling from it would write a manifest
         that looks complete and is not."""

--- a/tests/test_launch_manager_hosts.py
+++ b/tests/test_launch_manager_hosts.py
@@ -31,12 +31,23 @@ class LaunchManagerTestCase(unittest.TestCase):
             f.write(text)
         return path
 
+    def manifest(self, name, body=""):
+        """A manifest with every required element, so the only findings are the ones a test
+        sets up - a missing <license> raises a critical error that reaches the same summary."""
+        return (
+            '<?xml version="1.0"?>\n'
+            f'<package format="3">\n'
+            f"  <name>{name}</name>\n"
+            "  <version>0.0.0</version>\n"
+            "  <description>d</description>\n"
+            '  <maintainer email="dev@example.com">dev</maintainer>\n'
+            "  <license>MIT</license>\n"
+            f"{body}</package>\n"
+        )
+
     def package(self, name):
         directory = os.path.join(self.root, name)
-        self.write(
-            os.path.join(directory, "package.xml"),
-            f'<package format="3"><name>{name}</name></package>',
-        )
+        self.write(os.path.join(directory, "package.xml"), self.manifest(name))
         return directory
 
     def config(self, package_dir, components, name="default.yaml"):
@@ -179,11 +190,12 @@ class TestTheValidatorDelegates(LaunchManagerTestCase):
     declares its own share. Without the allowance every reference reads as missing here."""
 
     def install_set(self, name, host, deps):
-        body = "".join(f"<exec_depend>{one}</exec_depend>" for one in deps)
+        body = "".join(f"  <exec_depend>{one}</exec_depend>\n" for one in deps)
+        body += (
+            f"  <export><launch_manager_host>{host}</launch_manager_host></export>\n"
+        )
         self.write(
-            os.path.join(self.root, name, "package.xml"),
-            f'<package format="3"><name>{name}</name>{body}'
-            f"<export><launch_manager_host>{host}</launch_manager_host></export></package>",
+            os.path.join(self.root, name, "package.xml"), self.manifest(name, body)
         )
 
     def setUp(self):
@@ -219,6 +231,32 @@ class TestTheValidatorDelegates(LaunchManagerTestCase):
         self.install_set("app_gripper", "gripper", [])
 
         self.assertEqual(1, len(self.missing_for_app()))
+
+    def test_a_host_with_no_install_set_does_not_sign_off_as_corrected(self):
+        """Creating the missing package is not something the tool can do, so a run whose only
+        finding is this one must not print the success line beside its own error."""
+        from package_xml_validation.package_xml_validator import PackageXmlValidator
+
+        # gripper is fully declared, so the unclaimed jetson is the run's only finding - any
+        # other error would reach the same summary by a different route and prove nothing.
+        self.config(self.app, [("a_driver", ["gripper", "jetson"])])
+        self.install_set("app_gripper", "gripper", ["driver"])
+
+        validator = PackageXmlValidator(check_rosdeps=False)
+        with self.assertLogs("package_xml_validation.package_xml_validator") as logs:
+            valid = validator.check_and_format([self.root])
+
+        self.assertFalse(valid)
+        self.assertTrue(
+            any("No package claims host 'jetson'" in one for one in logs.output)
+        )
+        self.assertFalse(
+            any(
+                "Corrected `package.xml` files successfully" in one
+                for one in logs.output
+            ),
+            "the run signed off as successful while reporting a gap it cannot fix",
+        )
 
 
 class TestWhenItCannotAnswer(LaunchManagerTestCase):

--- a/tests/test_launch_manager_hosts.py
+++ b/tests/test_launch_manager_hosts.py
@@ -1,0 +1,280 @@
+"""Deriving what each launch-manager host runs, from the configuration and the launch trees."""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from package_xml_validation.helpers.launch_manager import derive
+
+
+class LaunchManagerTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.prefix = os.path.join(self.root, "install")
+        self._env = mock.patch.dict(os.environ, {"AMENT_PREFIX_PATH": self.prefix})
+        self._env.start()
+        # The shared component library exists but is empty unless a test fills it, which is
+        # the normal case: most components are defined by the repository itself.
+        os.makedirs(
+            os.path.join(self.prefix, "share", "launch_manager_common_components")
+        )
+
+    def tearDown(self):
+        self._env.stop()
+        self._tmp.cleanup()
+
+    def write(self, path, text):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def package(self, name):
+        directory = os.path.join(self.root, name)
+        self.write(
+            os.path.join(directory, "package.xml"),
+            f'<package format="3"><name>{name}</name></package>',
+        )
+        return directory
+
+    def config(self, package_dir, components, name="default.yaml"):
+        lines = ["components:"]
+        for component, hosts in components:
+            lines.append(f"  - name: {component}")
+            if isinstance(hosts, str):
+                lines.append(f"    hosts: {hosts}")
+            elif hosts:
+                lines.append("    hosts:")
+                lines.extend(f"      - {one}" for one in hosts)
+        self.write(
+            os.path.join(package_dir, "launch_manager_configs", name),
+            "\n".join(lines) + "\n",
+        )
+
+    def component(self, package_dir, name, launches, relative=""):
+        """A component that starts `<package>/launch/<package>.launch.yaml`."""
+        self.write(
+            os.path.join(
+                package_dir, "launch_manager_components", relative, f"{name}.yaml"
+            ),
+            f"launch:\n  package: {launches}\n  launch_file: {launches}.launch.yaml\n",
+        )
+
+    def installed_launch_file(self, package, names):
+        """An installed package whose launch file names other packages."""
+        body = "".join(f"  - node:\n      pkg: {one}\n" for one in names)
+        self.write(
+            os.path.join(
+                self.prefix, "share", package, "launch", f"{package}.launch.yaml"
+            ),
+            f"launch:\n{body}",
+        )
+
+    def dirs(self):
+        return sorted(
+            os.path.join(self.root, one)
+            for one in os.listdir(self.root)
+            if os.path.isfile(os.path.join(self.root, one, "package.xml"))
+        )
+
+
+class TestWhatAHostRuns(LaunchManagerTestCase):
+    def test_it_follows_the_component_into_the_launch_tree(self):
+        """The point of the derivation: not the package the component names, but everything
+        the launch file behind it pulls in."""
+        self.installed_launch_file("driver", ["deep_dependency"])
+        app = self.package("app")
+        self.component(app, "a_driver", "driver")
+        self.config(app, [("a_driver", "gripper")])
+
+        found = derive(self.dirs())
+
+        self.assertTrue(found.complete, found.problems + found.unresolved)
+        self.assertEqual({"driver", "deep_dependency"}, found.packages["gripper"])
+
+    def test_a_component_in_a_subdirectory_is_found(self):
+        """Components are routinely grouped, e.g. into a firmware_drivers/ folder."""
+        self.installed_launch_file("driver", [])
+        app = self.package("app")
+        self.component(app, "a_driver", "driver", relative="firmware_drivers")
+        self.config(app, [("a_driver", "gripper")])
+
+        found = derive(self.dirs())
+
+        self.assertTrue(found.complete, found.problems + found.unresolved)
+        self.assertEqual({"driver"}, found.packages["gripper"])
+
+    def test_a_component_from_the_shared_library_is_found(self):
+        """Some components are defined once and installed for every robot."""
+        self.installed_launch_file("driver", [])
+        self.write(
+            os.path.join(
+                self.prefix,
+                "share",
+                "launch_manager_common_components",
+                "launch_manager_components",
+                "shared_thing.yaml",
+            ),
+            "launch:\n  package: driver\n  launch_file: driver.launch.yaml\n",
+        )
+        app = self.package("app")
+        self.config(app, [("shared_thing", "main")])
+
+        found = derive(self.dirs())
+
+        self.assertTrue(found.complete, found.problems + found.unresolved)
+        self.assertEqual({"driver"}, found.packages["main"])
+
+    def test_the_repository_overrides_a_shared_component(self):
+        self.installed_launch_file("shared_driver", [])
+        self.installed_launch_file("local_driver", [])
+        self.write(
+            os.path.join(
+                self.prefix,
+                "share",
+                "launch_manager_common_components",
+                "thing.yaml",
+            ),
+            "launch:\n  package: shared_driver\n  launch_file: shared_driver.launch.yaml\n",
+        )
+        app = self.package("app")
+        self.component(app, "thing", "local_driver")
+        self.config(app, [("thing", "main")])
+
+        found = derive(self.dirs())
+
+        self.assertEqual({"local_driver"}, found.packages["main"])
+
+    def test_a_component_on_two_hosts_counts_for_both(self):
+        self.installed_launch_file("driver", [])
+        app = self.package("app")
+        self.component(app, "a_driver", "driver")
+        self.config(app, [("a_driver", ["main", "gripper"])])
+
+        found = derive(self.dirs())
+
+        self.assertEqual({"driver"}, found.packages["main"])
+        self.assertEqual({"driver"}, found.packages["gripper"])
+
+    def test_every_configuration_counts(self):
+        """A robot may be started with any of them, so a package only one configuration needs
+        is still a package the host has to have installed."""
+        self.installed_launch_file("everyday", [])
+        self.installed_launch_file("special", [])
+        app = self.package("app")
+        self.component(app, "everyday_thing", "everyday")
+        self.component(app, "special_thing", "special")
+        self.config(app, [("everyday_thing", "main")], name="default.yaml")
+        self.config(app, [("special_thing", "main")], name="maze.yaml")
+
+        found = derive(self.dirs())
+
+        self.assertEqual({"everyday", "special"}, found.packages["main"])
+
+
+class TestTheValidatorDelegates(LaunchManagerTestCase):
+    """The configuration package's launch files name what every host runs; each install set
+    declares its own share. Without the allowance every reference reads as missing here."""
+
+    def install_set(self, name, host, deps):
+        body = "".join(f"<exec_depend>{one}</exec_depend>" for one in deps)
+        self.write(
+            os.path.join(self.root, name, "package.xml"),
+            f'<package format="3"><name>{name}</name>{body}'
+            f"<export><launch_manager_host>{host}</launch_manager_host></export></package>",
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.installed_launch_file("driver", [])
+        self.app = self.package("app")
+        self.write(
+            os.path.join(self.app, "launch", "app.launch.yaml"),
+            "launch:\n  - node:\n      pkg: driver\n",
+        )
+        self.component(self.app, "a_driver", "driver")
+        self.config(self.app, [("a_driver", "gripper")])
+
+    def missing_for_app(self):
+        from package_xml_validation.package_xml_validator import PackageXmlValidator
+
+        validator = PackageXmlValidator(check_only=True, check_rosdeps=False)
+        # The exact logger: get_logger sets propagate=False, so a parent name sees nothing.
+        with self.assertLogs("package_xml_validation.package_xml_validator") as logs:
+            validator.check_and_format([self.root])
+        return [
+            one
+            for one in logs.output
+            if "Missing <exec_depend>" in one and "app/package.xml" in one
+        ]
+
+    def test_a_reference_an_install_set_declares_is_not_missing_here(self):
+        self.install_set("app_gripper", "gripper", ["driver"])
+
+        self.assertEqual([], self.missing_for_app())
+
+    def test_a_reference_nobody_declares_still_is(self):
+        self.install_set("app_gripper", "gripper", [])
+
+        self.assertEqual(1, len(self.missing_for_app()))
+
+
+class TestWhenItCannotAnswer(LaunchManagerTestCase):
+    """An incomplete derivation must say so. Callers fill manifests from this."""
+
+    def test_an_unreadable_component_is_named_and_marks_it_incomplete(self):
+        app = self.package("app")
+        self.config(app, [("nobody_defines_this", "main")])
+
+        found = derive(self.dirs())
+
+        self.assertEqual(["nobody_defines_this"], found.unresolved)
+        self.assertFalse(found.complete)
+
+    def test_two_configuration_packages_derive_nothing(self):
+        """Which one describes the hosts is not something to guess at."""
+        for name in ("app", "other"):
+            package = self.package(name)
+            self.config(package, [("a_driver", "main")])
+
+        found = derive(self.dirs())
+
+        self.assertEqual({}, found.packages)
+        self.assertFalse(found.complete)
+        self.assertIn("cannot tell which", " ".join(found.problems))
+
+    def test_no_configuration_package_derives_nothing(self):
+        self.package("app")
+
+        found = derive(self.dirs())
+
+        self.assertEqual({}, found.packages)
+        self.assertFalse(found.complete)
+
+    def test_a_missing_shared_library_marks_it_incomplete(self):
+        """Without a built workspace the shared components cannot be read, so the sets are
+        short by an unknown amount - which must not read as a clean result."""
+        self.installed_launch_file("driver", [])
+        app = self.package("app")
+        self.component(app, "a_driver", "driver")
+        self.config(app, [("a_driver", "main")])
+
+        with mock.patch.dict(os.environ, {"AMENT_PREFIX_PATH": ""}):
+            found = derive(self.dirs())
+
+        self.assertFalse(found.complete)
+        self.assertIn("launch_manager_common_components", " ".join(found.problems))
+
+    def test_an_unparsable_configuration_is_reported(self):
+        app = self.package("app")
+        self.write(
+            os.path.join(app, "launch_manager_configs", "default.yaml"),
+            "components:\n  - [unclosed\n",
+        )
+
+        found = derive(self.dirs())
+
+        self.assertFalse(found.complete)
+        self.assertIn("could not be read", " ".join(found.problems))


### PR DESCRIPTION
## Summary
Some workspaces keep every launch file in one package and declare the dependencies in sibling *install sets*, one per machine, the shape you get when a robot's computers aren't all big enough to install everything. Neither check could make sense of that: the package naming a dependency isn't the package declaring it. On `athena_driver_launch` that meant 12 false findings from `format-package-xml` and 27 from `check-launch-tree`, worked around with `--exclude-package`, which switched the checks off entirely.

The mapping already exists in the repo: `launch_manager_configs` assigns a component to a host, and the component definition names the launch file it starts. Following that launch file derives what each host needs.

### Usage

A package says which machine it is the install set for:

```xml
<export>
  <build_type>ament_cmake</build_type>
  <launch_manager_host>athena-gripper</launch_manager_host>
</export>
```
The validator then checks that install set against everything its host launches, and --auto-fill-missing-deps adds what's missing. check-launch-tree stops blaming the shared launch package and names the install set instead.